### PR TITLE
Enable dashboard stat navigation

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -543,7 +543,8 @@
     var app = {
         user: null,
         isOnline: navigator.onLine,
-        loadingTimeout: 15000
+        loadingTimeout: 15000,
+        dateFilter: 'all'
     };
 
     /**
@@ -554,6 +555,12 @@
      */
     document.addEventListener('DOMContentLoaded', function() {
         console.log('🚀 Assignments page loading...');
+
+        const params = new URLSearchParams(window.location.search);
+        const dateParam = params.get('date');
+        if (dateParam) {
+            app.dateFilter = dateParam.toLowerCase();
+        }
 
         setTimeout(function() {
             if (currentRequests.length === 0 && activeRiders.length === 0) {
@@ -935,7 +942,7 @@ if (!document.getElementById('debug-styles')) {
         currentRequests = Array.isArray(data) ? data : [];
         console.log('📊 Stored requests count:', currentRequests.length);
 
-        renderRequestsList();
+        filterRequests();
     }
 
     /**
@@ -1038,10 +1045,29 @@ if (!document.getElementById('debug-styles')) {
             var matchesSearch = !searchTerm ||
                 request.id.toLowerCase().indexOf(searchTerm) !== -1 ||
                 request.requesterName.toLowerCase().indexOf(searchTerm) !== -1;
-            
+
             var matchesStatus = activeStatus === 'all' || request.status === activeStatus;
-            
-            return matchesSearch && matchesStatus && ['New', 'Pending', 'Assigned', 'Unassigned'].indexOf(request.status) !== -1;
+
+            var matchesDate = true;
+            if (app.dateFilter === 'today') {
+                var today = new Date().toISOString().slice(0, 10);
+                matchesDate = request.eventDate === today;
+            } else if (app.dateFilter === 'week') {
+                try {
+                    var reqDate = new Date(request.eventDate);
+                    var now = new Date();
+                    var start = new Date(now);
+                    start.setDate(now.getDate() - now.getDay());
+                    start.setHours(0,0,0,0);
+                    var end = new Date(start);
+                    end.setDate(start.getDate() + 6);
+                    matchesDate = reqDate >= start && reqDate <= end;
+                } catch (e) {
+                    matchesDate = true;
+                }
+            }
+
+            return matchesSearch && matchesStatus && matchesDate && ['New', 'Pending', 'Assigned', 'Unassigned'].indexOf(request.status) !== -1;
         });
 
         renderFilteredRequests(filtered);

--- a/index.html
+++ b/index.html
@@ -350,19 +350,19 @@
             <div class="card">
                 <h3>📊 System Overview</h3>
                 <div class="stats-grid">
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToRiders('Active')">
                         <span class="stat-number" id="activeRiders">-</span>
                         <div class="stat-label">Active Riders</div>
                     </div>
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToRequests('Pending')">
                         <span class="stat-number" id="pendingRequests">-</span>
                         <div class="stat-label">Pending Requests</div>
                     </div>
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToAssignments('today')">
                         <span class="stat-number" id="todayAssignments">-</span>
                         <div class="stat-label">Today's Assignments</div>
                     </div>
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToAssignments('week')">
                         <span class="stat-number" id="weekAssignments">-</span>
                         <div class="stat-label">This Week</div>
                     </div>
@@ -668,6 +668,18 @@
 
     function openAssignments() {
         window.location.href = '?page=assignments';
+    }
+
+    function goToRiders(status) {
+        window.location.href = '?page=riders&status=' + encodeURIComponent(status);
+    }
+
+    function goToRequests(status) {
+        window.location.href = '?page=requests&status=' + encodeURIComponent(status);
+    }
+
+    function goToAssignments(range) {
+        window.location.href = '?page=assignments&date=' + encodeURIComponent(range);
     }
 
     function sendBulkNotifications() {

--- a/requests.html
+++ b/requests.html
@@ -565,6 +565,15 @@
      * @listens DOMContentLoaded
      */
     document.addEventListener('DOMContentLoaded', function() {
+        const params = new URLSearchParams(window.location.search);
+        const statusParam = params.get('status');
+        if (statusParam) {
+            const statusFilter = document.getElementById('statusFilter');
+            if (statusFilter) {
+                statusFilter.value = statusParam;
+            }
+        }
+
         loadPageData();
         document.getElementById('statusFilter').addEventListener('change', loadPageData);
     });

--- a/riders.html
+++ b/riders.html
@@ -666,6 +666,16 @@
     // Initialize page
     document.addEventListener('DOMContentLoaded', () => {
         console.log('🚀 Riders page loading...');
+
+        const params = new URLSearchParams(window.location.search);
+        const statusParam = params.get('status');
+        if (statusParam) {
+            const statusFilter = document.getElementById('statusFilter');
+            if (statusFilter) {
+                statusFilter.value = statusParam;
+            }
+        }
+
         loadRidersData();
         setupEventListeners();
     });
@@ -1202,9 +1212,20 @@ function handleRidersDataSuccess(data) {
     updateStats(data.stats);
     renderRidersTable(app.filteredRiders); // Use filtered riders
     showTable();
-    
+
     // IMPORTANT: Setup search after data is loaded
     setupEventListeners();
+
+    // Apply filter from URL if provided
+    const params = new URLSearchParams(window.location.search);
+    const statusParam = params.get('status');
+    if (statusParam) {
+      const statusFilter = document.getElementById('statusFilter');
+      if (statusFilter) {
+        statusFilter.value = statusParam;
+        filterRiders();
+      }
+    }
     
     console.log(`🔍 Search ready with ${app.riders.length} riders`);
   } else {


### PR DESCRIPTION
## Summary
- make dashboard stats clickable for filtered navigation
- update riders page to apply status filter from URL
- update requests page to handle status filter via URL
- add date filtering for assignments page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404f80584c8323af5ef99753dd7e21