### PR TITLE
Enable dashboard stat navigation

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -543,7 +543,8 @@
     var app = {
         user: null,
         isOnline: navigator.onLine,
-        loadingTimeout: 15000
+        loadingTimeout: 15000,
+        dateFilter: 'all'
     };
 
     /**
@@ -554,6 +555,12 @@
      */
     document.addEventListener('DOMContentLoaded', function() {
         console.log('🚀 Assignments page loading...');
+
+        const params = new URLSearchParams(window.location.search);
+        const dateParam = params.get('date');
+        if (dateParam) {
+            app.dateFilter = dateParam.toLowerCase();
+        }
 
         setTimeout(function() {
             if (currentRequests.length === 0 && activeRiders.length === 0) {
@@ -935,7 +942,7 @@ if (!document.getElementById('debug-styles')) {
         currentRequests = Array.isArray(data) ? data : [];
         console.log('📊 Stored requests count:', currentRequests.length);
 
-        renderRequestsList();
+        filterRequests();
     }
 
     /**
@@ -1038,273 +1045,33 @@ if (!document.getElementById('debug-styles')) {
             var matchesSearch = !searchTerm ||
                 request.id.toLowerCase().indexOf(searchTerm) !== -1 ||
                 request.requesterName.toLowerCase().indexOf(searchTerm) !== -1;
-            
+
             var matchesStatus = activeStatus === 'all' || request.status === activeStatus;
-            
-            return matchesSearch && matchesStatus && ['New', 'Pending', 'Assigned', 'Unassigned'].indexOf(request.status) !== -1;
+
+            var matchesDate = true;
+            if (app.dateFilter === 'today') {
+                var today = new Date().toISOString().slice(0, 10);
+                matchesDate = request.eventDate === today;
+            } else if (app.dateFilter === 'week') {
+                try {
+                    var reqDate = new Date(request.eventDate);
+                    var now = new Date();
+                    var start = new Date(now);
+                    start.setDate(now.getDate() - now.getDay());
+                    start.setHours(0,0,0,0);
+                    var end = new Date(start);
+                    end.setDate(start.getDate() + 6);
+                    matchesDate = reqDate >= start && reqDate <= end;
+                } catch (e) {
+                    matchesDate = true;
+                }
+            }
+
+            return matchesSearch && matchesStatus && matchesDate && ['New', 'Pending', 'Assigned', 'Unassigned'].indexOf(request.status) !== -1;
         });
 
         renderFilteredRequests(filtered);
     }
-<!-- Add this to your assignments.html <script> section for simple debugging -->
-
-// Simple debug function that uses existing functions
-function debugRidersSimple() {
-  console.log('🔍 Simple debug for riders issue...');
-  
-  if (typeof google !== 'undefined' && google.script && google.script.run) {
-    
-    // Test 1: Try to get basic riders data
-    console.log('📋 Test 1: Getting basic riders data...');
-    google.script.run
-      .withSuccessHandler(function(riders) {
-        console.log('✅ Basic riders result:', riders);
-        console.log(`📊 Type: ${typeof riders}, Length: ${riders?.length || 'N/A'}`);
-        
-        if (riders && riders.length > 0) {
-          console.log('👤 Sample rider:', riders[0]);
-          console.log('🔑 Rider keys:', Object.keys(riders[0]));
-        } else {
-          console.log('❌ No riders returned');
-        }
-      })
-      .withFailureHandler(function(error) {
-        console.error('❌ Basic riders failed:', error);
-      })
-      .getRiders(); // Use the existing getRiders function
-    
-    // Test 2: Try the assignments function
-    console.log('📋 Test 2: Getting active riders for assignments...');
-    google.script.run
-      .withSuccessHandler(function(riders) {
-        console.log('✅ Active riders for assignments:', riders);
-        console.log(`📊 Type: ${typeof riders}, Length: ${riders?.length || 'N/A'}`);
-        
-        if (riders && riders.length > 0) {
-          console.log('👤 Sample active rider:', riders[0]);
-        } else {
-          console.log('❌ No active riders for assignments');
-        }
-      })
-      .withFailureHandler(function(error) {
-        console.error('❌ Active riders for assignments failed:', error);
-      })
-      .getActiveRidersForAssignments();
-      
-    // Test 3: Try the web app riders function
-    console.log('📋 Test 3: Getting active riders for web app...');
-    google.script.run
-      .withSuccessHandler(function(riders) {
-        console.log('✅ Active riders for web app:', riders);
-        console.log(`📊 Type: ${typeof riders}, Length: ${riders?.length || 'N/A'}`);
-      })
-      .withFailureHandler(function(error) {
-        console.error('❌ Active riders for web app failed:', error);
-      })
-      .getActiveRidersForWebApp();
-      
-  } else {
-    console.error('❌ Google Apps Script not available');
-  }
-}
-
-// Test if we can load any rider data at all
-function testBasicRiderAccess() {
-  console.log('🧪 Testing basic rider access...');
-  
-  if (typeof google !== 'undefined' && google.script && google.script.run) {
-    google.script.run
-      .withSuccessHandler(function(result) {
-        console.log('✅ Test connection result:', result);
-        
-        // Now try to get riders
-        google.script.run
-          .withSuccessHandler(function(riders) {
-            console.log('✅ Got riders:', riders);
-            
-            if (riders && Array.isArray(riders) && riders.length > 0) {
-              console.log(`📊 Found ${riders.length} riders`);
-              console.log('👤 First rider:', riders[0]);
-              
-              // Check status values
-              const statuses = riders.map(r => r.status || r.Status || 'No Status');
-              const uniqueStatuses = [...new Set(statuses)];
-              console.log('📋 Unique status values:', uniqueStatuses);
-              
-              // Count by status
-              const statusCounts = {};
-              statuses.forEach(status => {
-                statusCounts[status] = (statusCounts[status] || 0) + 1;
-              });
-              console.log('📊 Status counts:', statusCounts);
-              
-            } else {
-              console.log('❌ No riders found or invalid data');
-            }
-          })
-          .withFailureHandler(function(error) {
-            console.error('❌ Failed to get riders:', error);
-          })
-          .getRiders();
-          
-      })
-      .withFailureHandler(function(error) {
-        console.error('❌ Test connection failed:', error);
-      })
-      .testServerConnection();
-  }
-}
-
-// Quick fix: Create riders manually for testing
-function createTestRiders() {
-  console.log('🔧 Creating test riders...');
-  
-  const testRiders = [
-    {
-      name: 'Test Rider 1',
-      jpNumber: 'TEST001',
-      phone: '555-0001',
-      email: 'test1@example.com',
-      carrier: 'Verizon',
-      status: 'Available'
-    },
-    {
-      name: 'Test Rider 2', 
-      jpNumber: 'TEST002',
-      phone: '555-0002',
-      email: 'test2@example.com',
-      carrier: 'AT&T',
-      status: 'Available'
-    }
-  ];
-  
-  console.log('✅ Test riders created:', testRiders);
-  
-  // Display these test riders
-  const ridersContainer = document.getElementById('ridersContainer') || 
-                         document.querySelector('.riders-list') ||
-                         document.querySelector('#activeRidersList');
-                         
-  if (ridersContainer) {
-    ridersContainer.innerHTML = `
-      <div class="test-riders">
-        <h3>🧪 Test Riders (for debugging)</h3>
-        ${testRiders.map(rider => `
-          <div class="rider-item">
-            <strong>${rider.name}</strong> (${rider.jpNumber})<br>
-            📞 ${rider.phone} | 📧 ${rider.email}<br>
-            📡 ${rider.carrier} | ✅ ${rider.status}
-          </div>
-        `).join('')}
-        <button onclick="testBasicRiderAccess()" class="btn btn-primary">
-          🔍 Debug Real Riders
-        </button>
-      </div>
-    `;
-  }
-  
-  return testRiders;
-}
-
-// Check what functions are available
-function checkAvailableFunctions() {
-  console.log('🔍 Checking available server functions...');
-  
-  const functionsToTest = [
-    'getRiders',
-    'getActiveRidersForAssignments', 
-    'getActiveRidersForWebApp',
-    'getRidersData',
-    'testServerConnection',
-    'getPageDataForAssignments'
-  ];
-  
-  functionsToTest.forEach(funcName => {
-    try {
-      if (typeof google !== 'undefined' && google.script && google.script.run && google.script.run[funcName]) {
-        console.log(`✅ ${funcName} is available`);
-      } else {
-        console.log(`❌ ${funcName} is NOT available`);
-      }
-    } catch (error) {
-      console.log(`❓ ${funcName} - cannot determine availability`);
-    }
-  });
-}
-
-// Auto-run when page loads
-document.addEventListener('DOMContentLoaded', function() {
-  setTimeout(function() {
-    console.log('🔍 Auto-running simple debug...');
-    checkAvailableFunctions();
-    testBasicRiderAccess();
-  }, 1000);
-});
-
-// Add a manual debug button to the page
-function addDebugButton() {
-  const debugButton = document.createElement('button');
-  debugButton.innerHTML = '🔍 Debug Riders';
-  debugButton.className = 'btn btn-warning';
-  debugButton.style.position = 'fixed';
-  debugButton.style.top = '10px';
-  debugButton.style.right = '10px';
-  debugButton.style.zIndex = '9999';
-  debugButton.onclick = function() {
-    debugRidersSimple();
-    testBasicRiderAccess();
-  };
-  
-  document.body.appendChild(debugButton);
-}
-
-// Add debug button when page loads
-document.addEventListener('DOMContentLoaded', addDebugButton);
-
-// CSS for test riders display
-const testRiderStyles = `
-<style>
-.test-riders {
-  background: #fff3cd;
-  border: 1px solid #ffeaa7;
-  border-radius: 8px;
-  padding: 1rem;
-  margin: 1rem 0;
-}
-
-.test-riders h3 {
-  color: #856404;
-  margin-bottom: 1rem;
-}
-
-.rider-item {
-  background: white;
-  padding: 0.75rem;
-  margin: 0.5rem 0;
-  border-radius: 4px;
-  border-left: 4px solid #28a745;
-}
-
-.btn {
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  margin: 0.25rem;
-}
-
-.btn-primary { background: #007bff; color: white; }
-.btn-warning { background: #ffc107; color: #212529; }
-</style>
-`;
-
-// Add styles
-if (!document.getElementById('test-rider-styles')) {
-  const styleDiv = document.createElement('div');
-  styleDiv.id = 'test-rider-styles';
-  styleDiv.innerHTML = testRiderStyles;
-  document.head.appendChild(styleDiv);
-}
     /**
      * Renders a list of requests that have been filtered.
      * @param {Array<RequestItemAssignmentsPage>} requests - The array of request items to render.
@@ -1775,60 +1542,6 @@ if (!document.getElementById('test-rider-styles')) {
         showError(error.message || (typeof error === 'string' ? error : 'An unexpected error occurred'));
     }
 
-    /**
-     * Test function for manually triggering data loading from the console.
-     * Useful for debugging.
-     * @return {void}
-     */
-    function manualDataTest() {
-    console.log('🧪 Manual data test starting...');
-    
-    if (typeof google === 'undefined') {
-        console.error('❌ Google Apps Script not available');
-        return;
-    }
-    
-    console.log('Test 1: Basic server connection (getCurrentUser)...');
-    google.script.run
-        .withSuccessHandler(function(user) {
-            console.log('✅ Server connection OK, user:', user);
-            
-            console.log('Test 2: Loading requests (getFilteredRequestsForWebApp)...');
-            google.script.run
-                .withSuccessHandler(function(requests) {
-                    console.log('✅ Requests loaded:', requests);
-                    console.log('Count:', requests ? requests.length : 'null');
-                    if (requests && requests.length > 0) {
-                        handleRequestsLoaded(requests); // Assuming this function exists and is appropriate
-                    }
-                })
-                .withFailureHandler(function(error) {
-                    console.error('❌ Requests failed:', error);
-                })
-                .getFilteredRequestsForWebApp('All'); // Example function call
-            
-            console.log('Test 3: Loading riders (getActiveRidersForWebApp)...');
-            google.script.run
-                .withSuccessHandler(function(riders) {
-                    console.log('✅ Riders loaded:', riders);
-                    console.log('Count:', riders ? riders.length : 'null');
-                    if (riders && riders.length > 0) {
-                        handleRidersLoaded(riders); // Assuming this function exists
-                    }
-                })
-                .withFailureHandler(function(error) {
-                    console.error('❌ Riders failed:', error);
-                })
-                .getActiveRidersForWebApp(); // Example function call
-                
-        })
-        .withFailureHandler(function(error) {
-            console.error('❌ Basic server connection failed:', error);
-        })
-        .getCurrentUser(); // Test with a simple, existing function
-}
-
-window.manualDataTest = manualDataTest; // Make it accessible from console
-    </script>
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -350,19 +350,19 @@
             <div class="card">
                 <h3>📊 System Overview</h3>
                 <div class="stats-grid">
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToRiders('Active')">
                         <span class="stat-number" id="activeRiders">-</span>
                         <div class="stat-label">Active Riders</div>
                     </div>
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToRequests('Pending')">
                         <span class="stat-number" id="pendingRequests">-</span>
                         <div class="stat-label">Pending Requests</div>
                     </div>
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToAssignments('today')">
                         <span class="stat-number" id="todayAssignments">-</span>
                         <div class="stat-label">Today's Assignments</div>
                     </div>
-                    <div class="stat-item">
+                    <div class="stat-item" style="cursor:pointer" onclick="goToAssignments('week')">
                         <span class="stat-number" id="weekAssignments">-</span>
                         <div class="stat-label">This Week</div>
                     </div>
@@ -660,14 +660,33 @@
         showMessage('Some dashboard data may not be current. Please try refreshing.', 'warning');
     }
 
+    function navigateTo(page, params = {}) {
+        const base = window.location.href.split('?')[0];
+        const search = new URLSearchParams(params);
+        search.set('page', page);
+        window.location.href = base + '?' + search.toString();
+    }
+
     function createNewRequest() {
         if (confirm('Navigate to Requests page to create a new request?')) {
-            window.location.href = '?page=requests&action=create';
+            navigateTo('requests', { action: 'create' });
         }
     }
 
     function openAssignments() {
-        window.location.href = '?page=assignments';
+        navigateTo('assignments');
+    }
+
+    function goToRiders(status) {
+        navigateTo('riders', { status: status });
+    }
+
+    function goToRequests(status) {
+        navigateTo('requests', { status: status });
+    }
+
+    function goToAssignments(range) {
+        navigateTo('assignments', { date: range });
     }
 
     function sendBulkNotifications() {

--- a/requests.html
+++ b/requests.html
@@ -565,6 +565,15 @@
      * @listens DOMContentLoaded
      */
     document.addEventListener('DOMContentLoaded', function() {
+        const params = new URLSearchParams(window.location.search);
+        const statusParam = params.get('status');
+        if (statusParam) {
+            const statusFilter = document.getElementById('statusFilter');
+            if (statusFilter) {
+                statusFilter.value = statusParam;
+            }
+        }
+
         loadPageData();
         document.getElementById('statusFilter').addEventListener('change', loadPageData);
     });

--- a/riders.html
+++ b/riders.html
@@ -666,6 +666,16 @@
     // Initialize page
     document.addEventListener('DOMContentLoaded', () => {
         console.log('🚀 Riders page loading...');
+
+        const params = new URLSearchParams(window.location.search);
+        const statusParam = params.get('status');
+        if (statusParam) {
+            const statusFilter = document.getElementById('statusFilter');
+            if (statusFilter) {
+                statusFilter.value = statusParam;
+            }
+        }
+
         loadRidersData();
         setupEventListeners();
     });
@@ -1202,9 +1212,20 @@ function handleRidersDataSuccess(data) {
     updateStats(data.stats);
     renderRidersTable(app.filteredRiders); // Use filtered riders
     showTable();
-    
+
     // IMPORTANT: Setup search after data is loaded
     setupEventListeners();
+
+    // Apply filter from URL if provided
+    const params = new URLSearchParams(window.location.search);
+    const statusParam = params.get('status');
+    if (statusParam) {
+      const statusFilter = document.getElementById('statusFilter');
+      if (statusFilter) {
+        statusFilter.value = statusParam;
+        filterRiders();
+      }
+    }
     
     console.log(`🔍 Search ready with ${app.riders.length} riders`);
   } else {


### PR DESCRIPTION
## Summary
- make dashboard stats clickable for filtered navigation
- update riders page to apply status filter from URL
- update requests page to handle status filter via URL
- add date filtering for assignments page
- remove leftover debug helpers
- add generic `navigateTo` helper for consistent page changes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404f80584c8323af5ef99753dd7e21