### PR TITLE
Fix dynamic google.script.run call

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -991,7 +991,7 @@
                 hideLoadingOverlay();
                 showToast('Error saving request: ' + error.message);
             })
-            .[functionName](requestData);
+            [functionName](requestData);
     }
 
     /**


### PR DESCRIPTION
## Summary
- correct dynamic function call when saving a request

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68420f5883e8832398d504a14a2b6d3e