### PR TITLE
Remove rating column from reports

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1911,8 +1911,7 @@ function generateReportData(filters) {
         riderPerformance.push({
           name: riderName,
           assignments: assignments.length,
-          completionRate: assignments.length > 0 ? Math.round((completed / assignments.length) * 100) : 0,
-          rating: 4.5 
+          completionRate: assignments.length > 0 ? Math.round((completed / assignments.length) * 100) : 0
         });
       }
     });

--- a/reports.html
+++ b/reports.html
@@ -696,7 +696,6 @@
                                 <th>Rider</th>
                                 <th>Assignments</th>
                                 <th>Completion Rate</th>
-                                <th>Avg Rating</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -705,7 +704,6 @@
                                     <td>${rider.name}</td>
                                     <td>${rider.assignments}</td>
                                     <td>${rider.completionRate}%</td>
-                                    <td>${rider.rating}/5</td>
                                 </tr>
                             `).join('')}
                         </tbody>


### PR DESCRIPTION
## Summary
- drop avg rating from the Rider Performance section
- remove rating from generated report data

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684239048a408323b3b35541798a7178