### PR TITLE
Fix assign riders navigation

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1346,7 +1346,7 @@ function navigateTo(page, params = {}) {
 
     let url;
     if (typeof google !== 'undefined' && google.script && google.script.run) {
-        const base = window.location.origin + window.location.pathname;
+        const base = window.requestBaseUrl || (window.location.origin + '/exec');
         url = base + '?' + search.toString();
     } else {
         url = page + '.html?' + search.toString();


### PR DESCRIPTION
## Summary
- ensure Assign Riders uses the web app URL when navigating to assignments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68423eefcf7883238763decdb2dd8828