### PR TITLE
Improve request preselection on assignments page

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -1163,6 +1163,8 @@ if (!document.getElementById('debug-styles')) {
         var requestElement = document.querySelector('[data-request-id="' + requestId + '"]');
         if (requestElement) {
             requestElement.classList.add('selected');
+            // Ensure the selected request is visible when navigated via URL
+            requestElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
 
         selectedRequest = null;


### PR DESCRIPTION
## Summary
- ensure the selected request is scrolled into view when navigating to the assignments page with a requestId

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68424687699c8323bb977bff80cef93c