### PR TITLE
Fix rider modal width

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -324,7 +324,7 @@
             padding: 0;
             border-radius: 15px;
             width: 90%;
-            max-width: 600px;
+            max-width: 800px;
             max-height: 90vh;
             overflow-y: auto;
             box-shadow: 0 4px 20px rgba(0,0,0,0.3);


### PR DESCRIPTION
## Summary
- expand rider modal width to prevent text clipping

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68424c5ab62c8323ba6ce843836086f9