### PR TITLE
Show part-time rider count

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -112,11 +112,14 @@ function getPageDataForRiders() {
       inactiveRiders: riders.filter(r => 
         String(r.status || '').toLowerCase() === 'inactive'
       ).length,
-      onVacation: riders.filter(r => 
+      onVacation: riders.filter(r =>
         String(r.status || '').toLowerCase() === 'vacation'
       ).length,
-      inTraining: riders.filter(r => 
+      inTraining: riders.filter(r =>
         String(r.status || '').toLowerCase() === 'training'
+      ).length,
+      partTimeRiders: riders.filter(r =>
+        String(r.partTime || '').toLowerCase() === 'yes'
       ).length
     };
     
@@ -147,7 +150,8 @@ function getPageDataForRiders() {
         activeRiders: 0,
         inactiveRiders: 0,
         onVacation: 0,
-        inTraining: 0
+        inTraining: 0,
+        partTimeRiders: 0
       }
     };
   }

--- a/Code.gs
+++ b/Code.gs
@@ -2082,14 +2082,17 @@ function getPageDataForRiders() {
         String(r.status || '').toLowerCase() === 'available' ||
         String(r.status || '').trim() === ''
       ).length,
-      inactiveRiders: riders.filter(r => 
+      inactiveRiders: riders.filter(r =>
         String(r.status || '').toLowerCase() === 'inactive'
       ).length,
-      onVacation: riders.filter(r => 
+      onVacation: riders.filter(r =>
         String(r.status || '').toLowerCase() === 'vacation'
       ).length,
-      inTraining: riders.filter(r => 
+      inTraining: riders.filter(r =>
         String(r.status || '').toLowerCase() === 'training'
+      ).length,
+      partTimeRiders: riders.filter(r =>
+        String(r.partTime || '').toLowerCase() === 'yes'
       ).length
     };
     
@@ -2120,7 +2123,8 @@ function getPageDataForRiders() {
         activeRiders: 0,
         inactiveRiders: 0,
         onVacation: 0,
-        inTraining: 0
+        inTraining: 0,
+        partTimeRiders: 0
       }
     };
   }

--- a/riders.html
+++ b/riders.html
@@ -499,8 +499,8 @@
                     <div class="stat-label">Inactive</div>
                 </div>
                 <div class="stat-card warning">
-                    <span class="stat-number" id="onVacation">-</span>
-                    <div class="stat-label">On Vacation</div>
+                    <span class="stat-number" id="partTimeRiders">-</span>
+                    <div class="stat-label">Part Time Riders</div>
                 </div>
                 <div class="stat-card danger">
                     <span class="stat-number" id="inTraining">-</span>
@@ -813,7 +813,7 @@ function setupEventListeners() {
         document.getElementById('totalRiders').textContent = stats.totalRiders || 0;
         document.getElementById('activeRiders').textContent = stats.activeRiders || 0;
         document.getElementById('inactiveRiders').textContent = stats.inactiveRiders || 0;
-        document.getElementById('onVacation').textContent = stats.onVacation || 0;
+        document.getElementById('partTimeRiders').textContent = stats.partTimeRiders || 0;
         document.getElementById('inTraining').textContent = stats.inTraining || 0;
     }
 


### PR DESCRIPTION
## Summary
- replace the "On Vacation" stat card with "Part Time Riders"
- compute `partTimeRiders` stat in backend scripts
- update stats display logic on riders page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68424d7f0d848323848f934e9aca2ad8