### PR TITLE
Fix riders table not displaying on initial load

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -1291,6 +1291,11 @@ function handleRidersDataSuccess(data) {
     // IMPORTANT: Setup search after data is loaded
     setupEventListeners();
 
+    // Ensure initial results are visible even if no filter is applied
+    // Using the same filtering logic as the dropdowns avoids cases where the
+    // table remains empty until a filter change triggers re-rendering.
+    filterRiders();
+
     // Apply filter from URL if provided
     const params = new URLSearchParams(window.location.search);
     const statusParam = params.get('status');


### PR DESCRIPTION
## Summary
- ensure the riders table is rendered by invoking `filterRiders()` when data loads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68425047579483238239f338bb6e3e69