### PR TITLE
Fix riders stats update

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -746,7 +746,20 @@
         document.getElementById('inactiveRiders').textContent = stats.inactiveRiders || 0;
 
         document.getElementById('partTimeRiders').textContent = stats.partTimeRiders || 0;
-        document.getElementById('inTraining').textContent = stats.inTraining || 0;
+
+        const fullTimeEl = document.getElementById('fullTimeRiders');
+        if (fullTimeEl) {
+            const fullTimeCount =
+                stats.fullTimeRiders !== undefined
+                    ? stats.fullTimeRiders
+                    : (stats.totalRiders || 0) - (stats.partTimeRiders || 0);
+            fullTimeEl.textContent = fullTimeCount;
+        }
+
+        const trainingEl = document.getElementById('inTraining');
+        if (trainingEl) {
+            trainingEl.textContent = stats.inTraining || 0;
+        }
 
     }
 


### PR DESCRIPTION
## Summary
- avoid null element error in updateStats on Riders page
- compute full-time rider count if not provided

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842585afb7483239ff2f2864f39e20c