### PR TITLE
Fix saving of rider part-time field

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2336,7 +2336,11 @@ function formatTimeForDisplay(time) {
  * Get column value safely
  */
 function normalizeColumnName(name) {
-  return String(name || '').trim().toLowerCase();
+  return String(name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ');
 }
 
 function getColumnIndex(columnMap, columnName) {

--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -315,6 +315,7 @@ function addRider(riderData) {
     // Support common variations of the part time field
     const normalizedPartTime =
       normalizedData['part time'] ||
+      normalizedData['part-time'] ||
       normalizedData['parttimerider'] ||
       normalizedData['part time rider'] ||
       normalizedData['parttime'];
@@ -421,6 +422,7 @@ function updateRider(riderData) {
     // Handle possible variations of the part time field
     const normalizedPartTime =
       normalizedData['part time'] ||
+      normalizedData['part-time'] ||
       normalizedData['parttimerider'] ||
       normalizedData['part time rider'] ||
       normalizedData['parttime'];
@@ -577,7 +579,14 @@ function mapRowToRiderObject(row, columnMap, headers) {
   rider.phone = getColumnValue(row, columnMap, CONFIG.columns.riders.phone) || '';
   rider.email = getColumnValue(row, columnMap, CONFIG.columns.riders.email) || '';
   rider.status = getColumnValue(row, columnMap, CONFIG.columns.riders.status) || 'Active';
-  rider.partTime = getColumnValue(row, columnMap, CONFIG.columns.riders.partTime) || 'No';
+  let partTimeVal = getColumnValue(row, columnMap, CONFIG.columns.riders.partTime);
+  if (partTimeVal === null || partTimeVal === '') {
+    partTimeVal = getColumnValue(row, columnMap, 'Part Time Rider');
+  }
+  if (partTimeVal === null || partTimeVal === '') {
+    partTimeVal = getColumnValue(row, columnMap, 'Part-Time');
+  }
+  rider.partTime = partTimeVal || 'No';
   rider.certification = getColumnValue(row, columnMap, CONFIG.columns.riders.certification) || '';
   rider.totalAssignments = getColumnValue(row, columnMap, CONFIG.columns.riders.totalAssignments) || 0;
   rider.lastAssignmentDate = getColumnValue(row, columnMap, CONFIG.columns.riders.lastAssignmentDate) || '';

--- a/SheetServices.gs
+++ b/SheetServices.gs
@@ -146,7 +146,11 @@ function findColumn(headers, searchTerm) {
  * @return {any} The value of the column, or null if not found or if row/columnMap is invalid.
  */
 function normalizeColumnName(name) {
-  return String(name || '').trim().toLowerCase();
+  return String(name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ');
 }
 
 function getColumnIndex(columnMap, columnName) {


### PR DESCRIPTION
## Summary
- improve column name normalization to handle hyphens and underscores
- support `Part Time` column variants when adding or updating riders
- load alternate `Part Time` headers when reading riders

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842ebcabf388323897b9213c13fd6c7