### PR TITLE
Fix rider stats to skip Not Certified

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -102,24 +102,29 @@ function getPageDataForRiders() {
     const riders = getRiders(); // This should work now with our previous fixes
     
     // Calculate stats using the same filtered data
+    const certifiedRiders = riders.filter(r =>
+      String(r.certification || r['Certification'] || '').toLowerCase() !==
+      'not certified'
+    );
+
     const stats = {
-      totalRiders: riders.length,
-      activeRiders: riders.filter(r => 
-        String(r.status || '').toLowerCase() === 'active' || 
+      totalRiders: certifiedRiders.length,
+      activeRiders: certifiedRiders.filter(r =>
+        String(r.status || '').toLowerCase() === 'active' ||
         String(r.status || '').toLowerCase() === 'available' ||
         String(r.status || '').trim() === ''
       ).length,
-      inactiveRiders: riders.filter(r => 
+      inactiveRiders: certifiedRiders.filter(r =>
         String(r.status || '').toLowerCase() === 'inactive'
       ).length,
-      onVacation: riders.filter(r =>
+      onVacation: certifiedRiders.filter(r =>
         String(r.status || '').toLowerCase() === 'vacation'
       ).length,
 
-      inTraining: riders.filter(r =>
+      inTraining: certifiedRiders.filter(r =>
         String(r.status || '').toLowerCase() === 'training'
       ).length,
-      partTimeRiders: riders.filter(r =>
+      partTimeRiders: certifiedRiders.filter(r =>
         String(r.partTime || '').toLowerCase() === 'yes'
       ).length
     };

--- a/Code.gs
+++ b/Code.gs
@@ -2078,24 +2078,29 @@ function getPageDataForRiders() {
     const riders = getRiders(); // Uses consistent filtering
     
     // Calculate stats using consistent logic
+    const certifiedRiders = riders.filter(r =>
+      String(r.certification || r['Certification'] || '').toLowerCase() !==
+      'not certified'
+    );
+
     const stats = {
-      totalRiders: riders.length, // Matches displayed count
-      activeRiders: riders.filter(r => 
-        String(r.status || '').toLowerCase() === 'active' || 
+      totalRiders: certifiedRiders.length, // Matches displayed count
+      activeRiders: certifiedRiders.filter(r =>
+        String(r.status || '').toLowerCase() === 'active' ||
         String(r.status || '').toLowerCase() === 'available' ||
         String(r.status || '').trim() === ''
       ).length,
-      inactiveRiders: riders.filter(r =>
+      inactiveRiders: certifiedRiders.filter(r =>
         String(r.status || '').toLowerCase() === 'inactive'
       ).length,
-      onVacation: riders.filter(r =>
+      onVacation: certifiedRiders.filter(r =>
         String(r.status || '').toLowerCase() === 'vacation'
       ).length,
 
-      inTraining: riders.filter(r =>
+      inTraining: certifiedRiders.filter(r =>
         String(r.status || '').toLowerCase() === 'training'
       ).length,
-      partTimeRiders: riders.filter(r =>
+      partTimeRiders: certifiedRiders.filter(r =>
         String(r.partTime || '').toLowerCase() === 'yes'
       ).length
     };


### PR DESCRIPTION
## Summary
- exclude Not Certified riders when computing rider page stats

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee875270832383f725163b93315a