### PR TITLE
Add rider availability utilities

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -649,6 +649,85 @@ function checkRiderTimeConflict(riderName, eventDateStr, startTimeStr) {
     return false;
   }
 }
+
+/**
+ * Checks the rider's availability schedule for a specific datetime.
+ * @param {string|number} riderId Rider identifier or name.
+ * @param {Date|string} datetime Date and time to check.
+ * @return {boolean} True if the rider is available at that time.
+ */
+function getRiderAvailabilityForDate(riderId, datetime) {
+  try {
+    if (!riderId || !datetime) return true;
+    const checkDate = datetime instanceof Date ? new Date(datetime) : new Date(datetime);
+    if (isNaN(checkDate.getTime())) return true;
+
+    const availData = getRiderAvailabilityData();
+    if (!availData || !availData.data) return true;
+
+    const cm = availData.columnMap;
+    const idCol = CONFIG.columns.riderAvailability.riderId;
+    const dateCol = CONFIG.columns.riderAvailability.date;
+    const startCol = CONFIG.columns.riderAvailability.startTime;
+    const endCol = CONFIG.columns.riderAvailability.endTime;
+    const statusCol = CONFIG.columns.riderAvailability.status;
+
+    for (let i = 0; i < availData.data.length; i++) {
+      const row = availData.data[i];
+      const rowId = getColumnValue(row, cm, idCol);
+      if (String(rowId).trim() !== String(riderId).trim()) continue;
+
+      let rowDate = getColumnValue(row, cm, dateCol);
+      rowDate = rowDate instanceof Date ? new Date(rowDate) : parseDateString(rowDate);
+      if (!rowDate) continue;
+      rowDate.setHours(0, 0, 0, 0);
+      const cmp = new Date(checkDate); cmp.setHours(0,0,0,0);
+      if (rowDate.getTime() !== cmp.getTime()) continue;
+
+      let start = getColumnValue(row, cm, startCol);
+      let end = getColumnValue(row, cm, endCol);
+      const startDt = start ? parseTimeString(start) : null;
+      const endDt = end ? parseTimeString(end) : null;
+      const checkDt = new Date(checkDate);
+      if (startDt) startDt.setFullYear(checkDate.getFullYear(), checkDate.getMonth(), checkDate.getDate());
+      if (endDt) endDt.setFullYear(checkDate.getFullYear(), checkDate.getMonth(), checkDate.getDate());
+
+      const matchesTime = (!startDt && !endDt) ||
+                          (startDt && !endDt && checkDt >= startDt) ||
+                          (!startDt && endDt && checkDt <= endDt) ||
+                          (startDt && endDt && checkDt >= startDt && checkDt <= endDt);
+
+      if (matchesTime) {
+        const status = String(getColumnValue(row, cm, statusCol) || '').toLowerCase();
+        return status === '' || status === 'available';
+      }
+    }
+    return true;
+  } catch (err) {
+    logError('Error in getRiderAvailabilityForDate', err);
+    return true;
+  }
+}
+
+/**
+ * Determines overall availability of a rider combining assignments and schedule.
+ * @param {string} riderName Rider name used in assignments sheet.
+ * @param {string} dateStr Event date string.
+ * @param {string} startTimeStr Start time string of the event.
+ * @return {boolean} True if the rider is available.
+ */
+function isRiderAvailable(riderName, dateStr, startTimeStr) {
+  const conflict = checkRiderTimeConflict(riderName, dateStr, startTimeStr);
+  if (conflict) return false;
+
+  const rider = getRiderDetails(riderName);
+  const riderId = rider ? rider.jpNumber || rider.riderId || rider.id : riderName;
+  const start = parseTimeString(startTimeStr);
+  const date = new Date(dateStr);
+  if (start) start.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
+  const available = getRiderAvailabilityForDate(riderId, start || date);
+  return available;
+}
 /**
  * Get rider schedule with formatted dates/times for dashboard display.
  * Filters assignments for the upcoming week.

--- a/Code.gs
+++ b/Code.gs
@@ -44,6 +44,7 @@ const CONFIG = {
     requests: "Requests",
     riders: "Riders",
     assignments: "Assignments",
+    riderAvailability: "Rider Availability",
     history: "History",
     settings: "Settings",
     log: "Log"
@@ -102,6 +103,13 @@ const CONFIG = {
       completedDate: 'Completed Date',
       calendarEventId: 'Calendar Event ID',
       notes: 'Notes'
+    },
+    riderAvailability: {
+      riderId: 'Rider ID',
+      date: 'Date',
+      startTime: 'Start Time',
+      endTime: 'End Time',
+      status: 'Status'
     }
   },
 
@@ -2294,6 +2302,9 @@ function ensureSheetsExist() {
         newSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
       } else if (sheetName === CONFIG.sheets.assignments) {
         const headers = Object.values(CONFIG.columns.assignments);
+        newSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+      } else if (sheetName === CONFIG.sheets.riderAvailability) {
+        const headers = Object.values(CONFIG.columns.riderAvailability);
         newSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
       }
     }

--- a/SheetServices.gs
+++ b/SheetServices.gs
@@ -410,6 +410,54 @@ function getAssignmentsData(useCache = true) {
   return data;
 }
 
+/**
+ * Retrieves all data from the "Rider Availability" sheet.
+ * Ensures the sheet exists with headers before loading data.
+ * @param {boolean} [useCache=true] Whether to use cached data.
+ * @return {object} Structured sheet data including headers and column map.
+ */
+function getRiderAvailabilityData(useCache = true) {
+  const sheetName = CONFIG.sheets.riderAvailability;
+  const headers = Object.values(CONFIG.columns.riderAvailability);
+  getOrCreateSheet(sheetName, headers);
+  return getSheetData(sheetName, useCache);
+}
+
+/**
+ * Saves a rider availability entry.
+ * Creates the sheet if it does not exist.
+ * @param {string|number} riderId Rider identifier.
+ * @param {string|Date} date The date of availability.
+ * @param {string|Date} startTime Start time of the availability window.
+ * @param {string|Date} endTime End time of the availability window.
+ * @param {string} status Availability status (e.g. "Available", "Unavailable").
+ * @return {object} Result object with success flag and optional error.
+ */
+function saveRiderAvailability(riderId, date, startTime, endTime, status) {
+  try {
+    const sheet = getOrCreateSheet(
+      CONFIG.sheets.riderAvailability,
+      Object.values(CONFIG.columns.riderAvailability)
+    );
+
+    const row = [
+      riderId,
+      parseDateString(date) || date,
+      startTime ? parseTimeString(startTime) : '',
+      endTime ? parseTimeString(endTime) : '',
+      status || 'Available'
+    ];
+
+    sheet.appendRow(row);
+    SpreadsheetApp.flush();
+    dataCache.clear('sheet_' + CONFIG.sheets.riderAvailability);
+    return { success: true };
+  } catch (error) {
+    logError('Error in saveRiderAvailability', error);
+    return { success: false, error: error.message };
+  }
+}
+
 
 /**
  * Retrieves rows of pending requests (status 'New', 'Pending', or 'Assigned').

--- a/assignments.html
+++ b/assignments.html
@@ -1424,14 +1424,14 @@ function updateAssignedRidersList() {
         activeRiders.forEach(function(rider) {
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
-                    .withSuccessHandler(function(conflict) {
-                        riderAvailability[rider.name] = conflict ? 'Unavailable' : 'Available';
+                    .withSuccessHandler(function(available) {
+                        riderAvailability[rider.name] = available ? 'Available' : 'Unavailable';
                         updateSingleRiderAvailability(rider.name);
                     })
                     .withFailureHandler(function(err) {
                         console.error('Availability check failed for', rider.name, err);
                     })
-                    .checkRiderTimeConflict(rider.name, selectedRequest.eventDate, selectedRequest.startTime);
+                    .isRiderAvailable(rider.name, selectedRequest.eventDate, selectedRequest.startTime);
             }
         });
     }


### PR DESCRIPTION
## Summary
- add `Rider Availability` sheet configuration
- ensure new sheet headers are created
- support reading and saving rider availability
- expose `getRiderAvailabilityForDate` and `isRiderAvailable` utilities
- update assignment page to use new availability check

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842eebb39d883239c01a01bab5388ef