### PR TITLE
Remove schedule links from global navigation

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -536,12 +536,20 @@ function createFallbackNavigation(currentPage = '') {
       { id: 'dashboard', url: baseUrl, label: '📊 Dashboard' },
       { id: 'requests', url: `${baseUrl}?page=requests`, label: '📋 Requests' },
       { id: 'assignments', url: `${baseUrl}?page=assignments`, label: '🏍️ Assignments' },
-      { id: 'riders', url: `${baseUrl}?page=riders`, label: '👥 Riders' },
-      { id: 'rider-schedule', url: `${baseUrl}?page=rider-schedule`, label: '📆 My Schedule' },
-      { id: 'admin-schedule', url: `${baseUrl}?page=admin-schedule`, label: '🗓️ Manage Schedules' },
+      { id: 'riders', url: `${baseUrl}?page=riders`, label: '👥 Riders' }
+    ];
+
+    if (['riders', 'rider-schedule', 'admin-schedule'].includes(currentPage)) {
+      pages.push(
+        { id: 'rider-schedule', url: `${baseUrl}?page=rider-schedule`, label: '📆 My Schedule' },
+        { id: 'admin-schedule', url: `${baseUrl}?page=admin-schedule`, label: '🗓️ Manage Schedules' }
+      );
+    }
+
+    pages.push(
       { id: 'notifications', url: `${baseUrl}?page=notifications`, label: '📱 Notifications' },
       { id: 'reports', url: `${baseUrl}?page=reports`, label: '📊 Reports' }
-    ];
+    );
   
   const navButtons = pages.map(page => {
     const activeClass = page.id === currentPage ? ' active' : '';
@@ -2917,12 +2925,20 @@ function getNavigationHtmlWithIframeSupport(currentPage = '') {
     `<a href="${BASE_URL}" class="nav-button ${currentPage === 'dashboard' ? 'active' : ''}" data-page="dashboard" data-url="${BASE_URL}" onclick="handleNavigation(this); return false;">📊 Dashboard</a>`,
     `<a href="${BASE_URL}?page=requests" class="nav-button ${currentPage === 'requests' ? 'active' : ''}" data-page="requests" data-url="${BASE_URL}?page=requests" onclick="handleNavigation(this); return false;">📋 Requests</a>`,
     `<a href="${BASE_URL}?page=assignments" class="nav-button ${currentPage === 'assignments' ? 'active' : ''}" data-page="assignments" data-url="${BASE_URL}?page=assignments" onclick="handleNavigation(this); return false;">🏍️ Assignments</a>`,
-    `<a href="${BASE_URL}?page=riders" class="nav-button ${currentPage === 'riders' ? 'active' : ''}" data-page="riders" data-url="${BASE_URL}?page=riders" onclick="handleNavigation(this); return false;">👥 Riders</a>`,
-    `<a href="${BASE_URL}?page=rider-schedule" class="nav-button ${currentPage === 'rider-schedule' ? 'active' : ''}" data-page="rider-schedule" data-url="${BASE_URL}?page=rider-schedule" onclick="handleNavigation(this); return false;">📆 My Schedule</a>`,
-    `<a href="${BASE_URL}?page=admin-schedule" class="nav-button ${currentPage === 'admin-schedule' ? 'active' : ''}" data-page="admin-schedule" data-url="${BASE_URL}?page=admin-schedule" onclick="handleNavigation(this); return false;">🗓️ Manage Schedules</a>`,
+    `<a href="${BASE_URL}?page=riders" class="nav-button ${currentPage === 'riders' ? 'active' : ''}" data-page="riders" data-url="${BASE_URL}?page=riders" onclick="handleNavigation(this); return false;">👥 Riders</a>`
+  ];
+
+  if (['riders', 'rider-schedule', 'admin-schedule'].includes(currentPage)) {
+    links.push(
+      `<a href="${BASE_URL}?page=rider-schedule" class="nav-button ${currentPage === 'rider-schedule' ? 'active' : ''}" data-page="rider-schedule" data-url="${BASE_URL}?page=rider-schedule" onclick="handleNavigation(this); return false;">📆 My Schedule</a>`,
+      `<a href="${BASE_URL}?page=admin-schedule" class="nav-button ${currentPage === 'admin-schedule' ? 'active' : ''}" data-page="admin-schedule" data-url="${BASE_URL}?page=admin-schedule" onclick="handleNavigation(this); return false;">🗓️ Manage Schedules</a>`
+    );
+  }
+
+  links.push(
     `<a href="${BASE_URL}?page=notifications" class="nav-button ${currentPage === 'notifications' ? 'active' : ''}" data-page="notifications" data-url="${BASE_URL}?page=notifications" onclick="handleNavigation(this); return false;">📱 Notifications</a>`,
     `<a href="${BASE_URL}?page=reports" class="nav-button ${currentPage === 'reports' ? 'active' : ''}" data-page="reports" data-url="${BASE_URL}?page=reports" onclick="handleNavigation(this); return false;">📊 Reports</a>`
-  ];
+  );
   
   const navigation = `<nav class="navigation" id="main-navigation">
         ${links.join('\n        ')}
@@ -3126,17 +3142,27 @@ function testForNavigationDuplicates() {
  */
 function createFallbackNavigation(currentPage = '') {
   const baseUrl = ScriptApp.getService().getUrl();
-  
-  return `<nav class="navigation">
-    <a href="${baseUrl}" class="nav-button ${currentPage === 'dashboard' ? 'active' : ''}" data-page="dashboard">📊 Dashboard</a>
-    <a href="${baseUrl}?page=requests" class="nav-button ${currentPage === 'requests' ? 'active' : ''}" data-page="requests">📋 Requests</a>
-    <a href="${baseUrl}?page=assignments" class="nav-button ${currentPage === 'assignments' ? 'active' : ''}" data-page="assignments">🏍️ Assignments</a>
-    <a href="${baseUrl}?page=riders" class="nav-button ${currentPage === 'riders' ? 'active' : ''}" data-page="riders">👥 Riders</a>
-    <a href="${baseUrl}?page=rider-schedule" class="nav-button ${currentPage === 'rider-schedule' ? 'active' : ''}" data-page="rider-schedule">📆 My Schedule</a>
-    <a href="${baseUrl}?page=admin-schedule" class="nav-button ${currentPage === 'admin-schedule' ? 'active' : ''}" data-page="admin-schedule">🗓️ Manage Schedules</a>
-    <a href="${baseUrl}?page=notifications" class="nav-button ${currentPage === 'notifications' ? 'active' : ''}" data-page="notifications">📱 Notifications</a>
-    <a href="${baseUrl}?page=reports" class="nav-button ${currentPage === 'reports' ? 'active' : ''}" data-page="reports">📊 Reports</a>
-  </nav>`;
+
+  const links = [
+    `<a href="${baseUrl}" class="nav-button ${currentPage === 'dashboard' ? 'active' : ''}" data-page="dashboard">📊 Dashboard</a>`,
+    `<a href="${baseUrl}?page=requests" class="nav-button ${currentPage === 'requests' ? 'active' : ''}" data-page="requests">📋 Requests</a>`,
+    `<a href="${baseUrl}?page=assignments" class="nav-button ${currentPage === 'assignments' ? 'active' : ''}" data-page="assignments">🏍️ Assignments</a>`,
+    `<a href="${baseUrl}?page=riders" class="nav-button ${currentPage === 'riders' ? 'active' : ''}" data-page="riders">👥 Riders</a>`
+  ];
+
+  if (['riders', 'rider-schedule', 'admin-schedule'].includes(currentPage)) {
+    links.push(
+      `<a href="${baseUrl}?page=rider-schedule" class="nav-button ${currentPage === 'rider-schedule' ? 'active' : ''}" data-page="rider-schedule">📆 My Schedule</a>`,
+      `<a href="${baseUrl}?page=admin-schedule" class="nav-button ${currentPage === 'admin-schedule' ? 'active' : ''}" data-page="admin-schedule">🗓️ Manage Schedules</a>`
+    );
+  }
+
+  links.push(
+    `<a href="${baseUrl}?page=notifications" class="nav-button ${currentPage === 'notifications' ? 'active' : ''}" data-page="notifications">📱 Notifications</a>`,
+    `<a href="${baseUrl}?page=reports" class="nav-button ${currentPage === 'reports' ? 'active' : ''}" data-page="reports">📊 Reports</a>`
+  );
+
+  return `<nav class="navigation">\n    ${links.join('\n    ')}\n  </nav>`;
 }
 function getNavigationHtmlWithDynamicUrls(currentPage = '') {
   try {
@@ -3149,12 +3175,20 @@ function getNavigationHtmlWithDynamicUrls(currentPage = '') {
       { id: 'dashboard', url: baseUrl, label: '📊 Dashboard' },
       { id: 'requests', url: `${baseUrl}?page=requests`, label: '📋 Requests' },
       { id: 'assignments', url: `${baseUrl}?page=assignments`, label: '🏍️ Assignments' },
-      { id: 'riders', url: `${baseUrl}?page=riders`, label: '👥 Riders' },
-      { id: 'rider-schedule', url: `${baseUrl}?page=rider-schedule`, label: '📆 My Schedule' },
-      { id: 'admin-schedule', url: `${baseUrl}?page=admin-schedule`, label: '🗓️ Manage Schedules' },
+      { id: 'riders', url: `${baseUrl}?page=riders`, label: '👥 Riders' }
+    ];
+
+    if (['riders', 'rider-schedule', 'admin-schedule'].includes(currentPage)) {
+      pages.push(
+        { id: 'rider-schedule', url: `${baseUrl}?page=rider-schedule`, label: '📆 My Schedule' },
+        { id: 'admin-schedule', url: `${baseUrl}?page=admin-schedule`, label: '🗓️ Manage Schedules' }
+      );
+    }
+
+    pages.push(
       { id: 'notifications', url: `${baseUrl}?page=notifications`, label: '📱 Notifications' },
       { id: 'reports', url: `${baseUrl}?page=reports`, label: '📊 Reports' }
-    ];
+    );
     
     const navButtons = pages.map(page => {
       const activeClass = page.id === currentPage ? ' active' : '';


### PR DESCRIPTION
## Summary
- add conditional checks in navigation generation so `My Schedule` and `Manage Schedules` only appear on riders-related pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843386ffbc083239fbf787a76c74e89