### PR TITLE
Fix new request redirect

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -705,6 +705,11 @@
         if (searchInput) {
             searchInput.addEventListener('input', sortAndDisplayRequests);
         }
+
+        const actionParam = params.get('action');
+        if (actionParam && actionParam.toLowerCase() === 'create') {
+            openNewRequestForm();
+        }
     });
 
     /**


### PR DESCRIPTION
## Summary
- trigger the new request modal when `action=create` is passed to requests page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843519d5d648323bef51cad0d9e054f