### PR TITLE
Implement basic login

### DIFF
--- a/Authentication.gs
+++ b/Authentication.gs
@@ -1,0 +1,67 @@
+/**
+ * Simple authentication service for the web app.
+ * Stores hashed passwords for a few demo users and
+ * uses UserProperties to keep track of login state.
+ */
+
+const AUTH_USERS = {
+  'admin@example.com': '713bfda78870bf9d1b261f565286f85e97ee614efe5f0faf7c34e7ca4f65baca', // adminpass
+  'rider@example.com': 'e1ba0863b3d203dfab67357b0ee651032aca5b10b1a780e8cf5de5abf6c229db'  // riderpass
+};
+
+/**
+ * Hashes a plain text password using SHA-256.
+ * @param {string} password The plain text password.
+ * @return {string} Hex encoded hash.
+ */
+function hashPassword(password) {
+  const digest = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, password);
+  return digest.map(b => ('0' + (b & 0xff).toString(16)).slice(-2)).join('');
+}
+
+/**
+ * Validates a user's credentials.
+ * @param {string} email The user email.
+ * @param {string} password The plain text password.
+ * @return {boolean} True if credentials are valid.
+ */
+function authenticateUser(email, password) {
+  if (!email || !password || !AUTH_USERS[email]) return false;
+  return AUTH_USERS[email] === hashPassword(password);
+}
+
+/**
+ * Logs a user in and stores a session token in UserProperties.
+ * @param {string} email The user email.
+ * @param {string} password The user password.
+ * @return {Object} Result of the login attempt.
+ */
+function loginUser(email, password) {
+  if (authenticateUser(email, password)) {
+    const props = PropertiesService.getUserProperties();
+    const token = Utilities.getUuid();
+    props.setProperty('authToken', token);
+    props.setProperty('authEmail', email);
+    return { success: true };
+  }
+  return { success: false, message: 'Invalid credentials' };
+}
+
+/**
+ * Clears the session token for the current user.
+ */
+function logoutUser() {
+  const props = PropertiesService.getUserProperties();
+  props.deleteProperty('authToken');
+  props.deleteProperty('authEmail');
+  return { success: true };
+}
+
+/**
+ * Checks whether the current user is logged in.
+ * @return {boolean} True if logged in.
+ */
+function isUserLoggedIn() {
+  const props = PropertiesService.getUserProperties();
+  return !!props.getProperty('authToken');
+}

--- a/Code.gs
+++ b/Code.gs
@@ -2635,6 +2635,14 @@ function doGet(e) {
     
     const pageName = (e && e.parameter && e.parameter.page) ? e.parameter.page : 'dashboard';
     console.log(`📄 Loading page: ${pageName}`);
+
+    if (!isUserLoggedIn() && pageName !== 'login') {
+      console.log('User not authenticated, redirecting to login');
+      const loginHtml = HtmlService.createHtmlOutputFromFile('login');
+      return loginHtml
+        .setTitle('Login')
+        .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+    }
     
     // Determine file name
     let fileName;
@@ -2647,6 +2655,7 @@ function doGet(e) {
       case 'admin-schedule': fileName = 'admin-schedule'; break;
       case 'notifications': fileName = 'notifications'; break;
       case 'reports': fileName = 'reports'; break;
+      case 'login': fileName = 'login'; break;
       default: fileName = 'index';
     }
     

--- a/_navigation.html
+++ b/_navigation.html
@@ -5,4 +5,21 @@
     <a href="?page=riders" class="nav-button" id="nav-riders" data-page="riders">👥 Riders</a>
     <a href="?page=notifications" class="nav-button" id="nav-notifications" data-page="notifications">📱 Notifications</a>
     <a href="?page=reports" class="nav-button" id="nav-reports" data-page="reports">📊 Reports</a>
+    <a href="?page=login" class="nav-button" id="nav-login" data-page="login">🔐 Login</a>
 </nav>
+<script>
+  if (typeof google !== 'undefined' && google.script && google.script.run) {
+    google.script.run.withSuccessHandler(function(loggedIn) {
+      var loginLink = document.getElementById('nav-login');
+      if (loggedIn) {
+        loginLink.textContent = '🚪 Logout';
+        loginLink.addEventListener('click', function(e) {
+          e.preventDefault();
+          google.script.run.withSuccessHandler(function(){
+            window.location.href = '?page=login';
+          }).logoutUser();
+        });
+      }
+    }).isUserLoggedIn();
+  }
+</script>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; background:#f5f5f5; padding:40px; }
+    form { max-width:300px; margin:auto; background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 5px rgba(0,0,0,0.1); }
+    input { display:block; width:100%; margin-bottom:10px; padding:8px; }
+    button { padding:8px 16px; }
+    #message { color:red; margin-bottom:10px; text-align:center; }
+  </style>
+</head>
+<body>
+  <form id="loginForm">
+    <h2>Login</h2>
+    <div id="message"></div>
+    <input type="email" id="email" placeholder="Email" required>
+    <input type="password" id="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <script>
+    const form = document.getElementById('loginForm');
+    const msg = document.getElementById('message');
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      msg.textContent = '';
+      google.script.run.withSuccessHandler(function(res) {
+        if (res && res.success) {
+          window.location.href = '?page=dashboard';
+        } else {
+          msg.textContent = 'Invalid credentials';
+        }
+      }).loginUser(form.email.value, form.password.value);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Authentication.gs` with simple hashed-password auth
- add a minimal login page
- integrate login into `doGet`
- show login link in navigation with logout support

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684372df5764832392b8c6c9da670610