### PR TITLE
Fix navigation URLs to always use deployed web app

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2959,25 +2959,27 @@ document.addEventListener('DOMContentLoaded', function() {
 function getNavigationHtmlWithIframeSupport(currentPage = '') {
   console.log(`🔗 Creating centered navigation for: ${currentPage}`);
 
-  // Use relative links so the navigation works regardless of deployment URL
+  // Always use the deployed web app URL as the base for all links
+  const baseUrl = getWebAppUrl();
+
   const links = [
-    `<a href="?page=dashboard" class="nav-button ${currentPage === 'dashboard' ? 'active' : ''}" data-page="dashboard" data-url="?page=dashboard" onclick="handleNavigation(this); return false;">📊 Dashboard</a>`,
-    `<a href="?page=requests" class="nav-button ${currentPage === 'requests' ? 'active' : ''}" data-page="requests" data-url="?page=requests" onclick="handleNavigation(this); return false;">📋 Requests</a>`,
-    `<a href="?page=assignments" class="nav-button ${currentPage === 'assignments' ? 'active' : ''}" data-page="assignments" data-url="?page=assignments" onclick="handleNavigation(this); return false;">🏍️ Assignments</a>`,
-    `<a href="?page=riders" class="nav-button ${currentPage === 'riders' ? 'active' : ''}" data-page="riders" data-url="?page=riders" onclick="handleNavigation(this); return false;">👥 Riders</a>`
+    `<a href="${baseUrl}" class="nav-button ${currentPage === 'dashboard' ? 'active' : ''}" data-page="dashboard" data-url="${baseUrl}" onclick="handleNavigation(this); return false;">📊 Dashboard</a>`,
+    `<a href="${baseUrl}?page=requests" class="nav-button ${currentPage === 'requests' ? 'active' : ''}" data-page="requests" data-url="${baseUrl}?page=requests" onclick="handleNavigation(this); return false;">📋 Requests</a>`,
+    `<a href="${baseUrl}?page=assignments" class="nav-button ${currentPage === 'assignments' ? 'active' : ''}" data-page="assignments" data-url="${baseUrl}?page=assignments" onclick="handleNavigation(this); return false;">🏍️ Assignments</a>`,
+    `<a href="${baseUrl}?page=riders" class="nav-button ${currentPage === 'riders' ? 'active' : ''}" data-page="riders" data-url="${baseUrl}?page=riders" onclick="handleNavigation(this); return false;">👥 Riders</a>`
   ];
 
   if (['riders', 'rider-schedule', 'admin-schedule'].includes(currentPage)) {
     links.push(
-      `<a href="?page=rider-schedule" class="nav-button ${currentPage === 'rider-schedule' ? 'active' : ''}" data-page="rider-schedule" data-url="?page=rider-schedule" onclick="handleNavigation(this); return false;">📆 My Schedule</a>`,
-      `<a href="?page=admin-schedule" class="nav-button ${currentPage === 'admin-schedule' ? 'active' : ''}" data-page="admin-schedule" data-url="?page=admin-schedule" onclick="handleNavigation(this); return false;">🗓️ Manage Schedules</a>`
+      `<a href="${baseUrl}?page=rider-schedule" class="nav-button ${currentPage === 'rider-schedule' ? 'active' : ''}" data-page="rider-schedule" data-url="${baseUrl}?page=rider-schedule" onclick="handleNavigation(this); return false;">📆 My Schedule</a>`,
+      `<a href="${baseUrl}?page=admin-schedule" class="nav-button ${currentPage === 'admin-schedule' ? 'active' : ''}" data-page="admin-schedule" data-url="${baseUrl}?page=admin-schedule" onclick="handleNavigation(this); return false;">🗓️ Manage Schedules</a>`
     );
   }
 
   links.push(
-    `<a href="?page=notifications" class="nav-button ${currentPage === 'notifications' ? 'active' : ''}" data-page="notifications" data-url="?page=notifications" onclick="handleNavigation(this); return false;">📱 Notifications</a>`,
-    `<a href="?page=reports" class="nav-button ${currentPage === 'reports' ? 'active' : ''}" data-page="reports" data-url="?page=reports" onclick="handleNavigation(this); return false;">📊 Reports</a>`,
-    `<a href="?page=login" class="nav-button ${currentPage === 'login' ? 'active' : ''}" id="nav-login" data-page="login" data-url="?page=login" onclick="handleNavigation(this); return false;">🔐 Login</a>`
+    `<a href="${baseUrl}?page=notifications" class="nav-button ${currentPage === 'notifications' ? 'active' : ''}" data-page="notifications" data-url="${baseUrl}?page=notifications" onclick="handleNavigation(this); return false;">📱 Notifications</a>`,
+    `<a href="${baseUrl}?page=reports" class="nav-button ${currentPage === 'reports' ? 'active' : ''}" data-page="reports" data-url="${baseUrl}?page=reports" onclick="handleNavigation(this); return false;">📊 Reports</a>`,
+    `<a href="${baseUrl}?page=login" class="nav-button ${currentPage === 'login' ? 'active' : ''}" id="nav-login" data-page="login" data-url="${baseUrl}?page=login" onclick="handleNavigation(this); return false;">🔐 Login</a>`
   );
   
   const navigation = `<nav class="navigation" id="main-navigation">

--- a/NotificationService.gs
+++ b/NotificationService.gs
@@ -847,10 +847,7 @@ function formatNotificationMessage(assignment, includeLinks = true) {
  */
 function getWebAppUrl() {
   try {
-    // Try to get the current web app URL
-    // You'll need to set this to your actual web app URL
-    const WEB_APP_URL = "https://script.google.com/macros/s/AKfycbyGPHwTNYnqK59cdsI6NVv5O5aBlrzSnulpVu-WJ86-1rlkT3PqIf_FAWgrFpcNbMVU/exec";
-    return WEB_APP_URL;
+    return ScriptApp.getService().getUrl();
   } catch (error) {
     console.log('Could not determine web app URL');
     return null;

--- a/_navigation.html
+++ b/_navigation.html
@@ -9,17 +9,23 @@
 </nav>
 <script>
   if (typeof google !== 'undefined' && google.script && google.script.run) {
-    google.script.run.withSuccessHandler(function(loggedIn) {
-      var loginLink = document.getElementById('nav-login');
-      if (loggedIn) {
-        loginLink.textContent = '🚪 Logout';
-        loginLink.addEventListener('click', function(e) {
-          e.preventDefault();
-          google.script.run.withSuccessHandler(function(){
-            window.location.href = '?page=login';
-          }).logoutUser();
-        });
-      }
-    }).isUserLoggedIn();
+    google.script.run.withSuccessHandler(function(url) {
+      document.querySelectorAll('nav.navigation a').forEach(function(a) {
+        var page = a.getAttribute('data-page');
+        a.href = page === 'dashboard' ? url : url + '?page=' + page;
+      });
+      google.script.run.withSuccessHandler(function(loggedIn) {
+        var loginLink = document.getElementById('nav-login');
+        if (loggedIn) {
+          loginLink.textContent = '🚪 Logout';
+          loginLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            google.script.run.withSuccessHandler(function(){
+              window.location.href = url + '?page=login';
+            }).logoutUser();
+          });
+        }
+      }).isUserLoggedIn();
+    }).getWebAppUrl();
   }
 </script>

--- a/assignments.html
+++ b/assignments.html
@@ -777,7 +777,7 @@ function displayNoRiders(message) {
           <button onclick="loadActiveRidersEnhanced()" class="btn btn-primary">
             🔄 Retry Loading
           </button>
-          <button onclick="window.open('?page=riders', '_blank')" class="btn btn-secondary">
+          <button onclick="google.script.run.withSuccessHandler(url => window.open(url + '?page=riders', '_blank')).getWebAppUrl();" class="btn btn-secondary">
             👥 Go to Riders Page
           </button>
         </div>

--- a/login.html
+++ b/login.html
@@ -30,7 +30,9 @@
         google.script.run
           .withSuccessHandler(function(res) {
             if (res && res.success) {
-              window.location.href = '?page=dashboard';
+              google.script.run.withSuccessHandler(function(url) {
+                window.location.href = url + '?page=dashboard';
+              }).getWebAppUrl();
             } else {
               msg.textContent = 'Invalid credentials';
             }

--- a/riders.html
+++ b/riders.html
@@ -2063,7 +2063,7 @@ function addScheduleLinks() {
 
   if (!nav.querySelector('[data-page="rider-schedule"]')) {
     const mySchedule = document.createElement('a');
-    mySchedule.href = '?page=rider-schedule';
+    google.script.run.withSuccessHandler(url => { mySchedule.href = url + '?page=rider-schedule'; }).getWebAppUrl();
     mySchedule.className = 'nav-button';
     mySchedule.id = 'nav-rider-schedule';
     mySchedule.dataset.page = 'rider-schedule';
@@ -2074,7 +2074,7 @@ function addScheduleLinks() {
 
   if (!nav.querySelector('[data-page="admin-schedule"]')) {
     const manageSchedules = document.createElement('a');
-    manageSchedules.href = '?page=admin-schedule';
+    google.script.run.withSuccessHandler(url => { manageSchedules.href = url + '?page=admin-schedule'; }).getWebAppUrl();
     manageSchedules.className = 'nav-button';
     manageSchedules.id = 'nav-admin-schedule';
     manageSchedules.dataset.page = 'admin-schedule';


### PR DESCRIPTION
## Summary
- build navigation links with absolute URLs using getWebAppUrl
- dynamically update static navigation HTML with the deployed URL
- redirect login success to the deployed dashboard URL
- update rider schedule links and riders page link to use the web app base

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68443310ede4832391b0e884d3b0b5a8