### PR TITLE
Fix Assign Riders navigation

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1385,7 +1385,15 @@ function navigateTo(page, params = {}) {
         if (currentEditingRequest && currentEditingRequest.requestId) {
             const requestId = currentEditingRequest.requestId;
             console.log('Navigating to assignments page for request:', requestId);
-            navigateTo('assignments', { requestId });
+
+            if (typeof google !== 'undefined' && google.script && google.script.run) {
+                google.script.run.withSuccessHandler(function(baseUrl) {
+                    const url = baseUrl + '?page=assignments&requestId=' + encodeURIComponent(requestId);
+                    window.location.href = url;
+                }).getWebAppUrl();
+            } else {
+                navigateTo('assignments', { requestId });
+            }
         } else {
             showToast('No request selected or request ID is missing. Cannot navigate to assignments.');
             console.error('redirectToAssignmentPage called without a valid currentEditingRequest or requestId.');


### PR DESCRIPTION
## Summary
- fix redirectToAssignmentPage so Assign Riders button navigates to assignments page using base URL from Apps Script

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684468b4162c8323bd267874e072c5df