### PR TITLE
Fix unassigned filter in assignments page

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -1111,7 +1111,12 @@ if (!document.getElementById('debug-styles')) {
                 request.requesterName.toLowerCase().indexOf(searchTerm) !== -1 ||
                 (request.ridersAssigned && request.ridersAssigned.toLowerCase().indexOf(searchTerm) !== -1);
 
-            var matchesStatus = activeStatus === 'all' || request.status === activeStatus;
+            var matchesStatus;
+            if (activeStatus === 'Unassigned') {
+                matchesStatus = request.status !== 'Assigned';
+            } else {
+                matchesStatus = activeStatus === 'all' || request.status === activeStatus;
+            }
 
             var matchesDate = true;
             if (app.dateFilter === 'today') {


### PR DESCRIPTION
## Summary
- include requests with `New` and `Pending` statuses when `Unassigned` filter is active

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68448803647483238919f9a15d74bb11