### PR TITLE
Add CSV export for rider activity report

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2174,10 +2174,49 @@ function generateRiderActivityReport(startDate, endDate) {
       hours: Math.round(riderMap[name].hours * 100) / 100
     })).sort((a, b) => b.hours - a.hours);
 
-    return { success: true, data };
+  return { success: true, data };
   } catch (error) {
     logError('Error in generateRiderActivityReport', error);
     return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Exports rider activity report as CSV.
+ * @param {string} startDate Start date in YYYY-MM-DD format.
+ * @param {string} endDate End date in YYYY-MM-DD format.
+ * @return {object} Result object with CSV content or error message.
+ */
+function exportRiderActivityCSV(startDate, endDate) {
+  try {
+    const report = generateRiderActivityReport(startDate, endDate);
+    if (!report.success) {
+      throw new Error(report.error || 'Failed to generate rider activity');
+    }
+
+    const headers = ['Rider', 'Escorts', 'Hours'];
+    const csvRows = [headers.join(',')];
+    report.data.forEach(r => {
+      const row = [
+        `"${String(r.name).replace(/"/g, '""')}"`,
+        r.escorts,
+        r.hours
+      ];
+      csvRows.push(row.join(','));
+    });
+
+    const csvContent = csvRows.join('\n');
+    const filename = `rider_activity_${startDate}_to_${endDate}.csv`;
+
+    return {
+      success: true,
+      csvContent: csvContent,
+      filename: filename,
+      count: report.data.length
+    };
+  } catch (error) {
+    logError('Error in exportRiderActivityCSV', error);
+    return { success: false, message: error.message };
   }
 }
 

--- a/reports.html
+++ b/reports.html
@@ -524,6 +524,9 @@
                 <button class="btn btn-primary" onclick="generateComprehensiveReport('rider')">
                     🏍️ Rider Activity Report
                 </button>
+                <button class="btn btn-success" onclick="exportRiderActivityCSV()">
+                    📥 Rider CSV
+                </button>
                 <button class="btn btn-primary" onclick="generateComprehensiveReport('financial')">
                     💰 Cost Analysis
                 </button>
@@ -911,6 +914,41 @@
                 w.document.write(html);
                 w.document.close();
             }
+        }
+
+        function exportRiderActivityCSV() {
+            const start = document.getElementById('startDate').value;
+            const end = document.getElementById('endDate').value;
+            if (!start || !end) {
+                showError('Please select a date range');
+                return;
+            }
+            showLoading('Exporting rider activity...');
+            if (typeof google !== 'undefined' && google.script && google.script.run) {
+                google.script.run
+                    .withSuccessHandler(handleRiderActivityCSV)
+                    .withFailureHandler(handleError)
+                    .exportRiderActivityCSV(start, end);
+            } else {
+                hideLoading();
+                showError('Google Apps Script not available.');
+            }
+        }
+
+        function handleRiderActivityCSV(result) {
+            hideLoading();
+            if (!result || !result.success) {
+                showError(result && result.message ? result.message : 'Failed to export');
+                return;
+            }
+            const blob = new Blob([result.csvContent], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = result.filename;
+            a.click();
+            URL.revokeObjectURL(url);
+            showSuccess(`Exported ${result.count} records`);
         }
 
         function exportChart(id) {


### PR DESCRIPTION
## Summary
- add server-side exportRiderActivityCSV helper
- add Rider CSV button on reports page
- implement exportRiderActivityCSV client logic

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68449e4766a48323b2f50a824fda6641