### PR TITLE
Set default reports range to last 30 days

### DIFF
--- a/reports.html
+++ b/reports.html
@@ -484,6 +484,7 @@
     <script>
         let reportData = {};
         let currentPeriod = { start: null, end: null };
+        const DEFAULT_REPORT_RANGE_DAYS = 30;
 
         document.addEventListener('DOMContentLoaded', function() {
             setDefaultDates();
@@ -497,10 +498,10 @@
 
         function setDefaultDates() {
             var today = new Date();
-            var thirtyDaysAgo = new Date(today);
-            thirtyDaysAgo.setDate(today.getDate() - 30);
+            var startDate = new Date(today);
+            startDate.setDate(today.getDate() - DEFAULT_REPORT_RANGE_DAYS);
 
-            document.getElementById('startDate').value = formatDateForInput(thirtyDaysAgo);
+            document.getElementById('startDate').value = formatDateForInput(startDate);
             document.getElementById('endDate').value = formatDateForInput(today);
         }
 


### PR DESCRIPTION
## Summary
- set a constant for the default report range days
- initialize report dates using the constant

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68459b354ba08323ab2cdef594e2109e