### PR TITLE
Allow multiple roles per user

### DIFF
--- a/user-management.html
+++ b/user-management.html
@@ -760,14 +760,17 @@
                 return;
             }
 
-            usersGrid.innerHTML = users.map(user => `
-                <div class="user-card ${user.role.toLowerCase()}">
+            usersGrid.innerHTML = users.map(user => {
+                const primaryRole = (user.roles && user.roles.length) ? user.roles[0] : user.role;
+                const roleLabel = (user.roles && user.roles.length) ? user.roles.join(', ') : user.role;
+                return `
+                <div class="user-card ${primaryRole.toLowerCase()}">
                     <div class="user-header">
                         <div class="user-avatar-large">${user.avatar || user.name.charAt(0).toUpperCase()}</div>
                         <div class="user-details-card">
                             <div class="user-name-large">${user.name}</div>
                             <div class="user-email">${user.email}</div>
-                            <span class="user-role-badge role-${user.role.toLowerCase()}">${user.role}</span>
+                            <span class="user-role-badge role-${primaryRole.toLowerCase()}">${roleLabel}</span>
                         </div>
                     </div>
                     
@@ -788,7 +791,7 @@
                         <button class="btn btn-warning btn-small" onclick="resetUserPassword('${user.id}')">
                             🔑 Reset
                         </button>
-                        ${user.role !== 'admin' ? `
+                        ${(user.roles || [user.role]).indexOf('admin') === -1 ? `
                             <button class="btn btn-danger btn-small" onclick="deactivateUser('${user.id}')">
                                 🚫 Deactivate
                             </button>
@@ -807,9 +810,10 @@
             let filteredUsers = allUsers;
             
             if (roleFilter) {
-                filteredUsers = filteredUsers.filter(user => 
-                    user.role.toLowerCase() === roleFilter.toLowerCase()
-                );
+                filteredUsers = filteredUsers.filter(user => {
+                    const roles = user.roles || [user.role];
+                    return roles.some(r => r.toLowerCase() === roleFilter.toLowerCase());
+                });
             }
             
             if (statusFilter) {
@@ -993,9 +997,13 @@
         function editUser(userId) {
             const user = allUsers.find(u => u.id === userId);
             if (user) {
-                const newRole = prompt(`Change role for ${user.name}:`, user.role);
-                if (newRole && ['admin', 'dispatcher', 'rider'].includes(newRole.toLowerCase())) {
-                    updateUserRole(userId, newRole.toLowerCase());
+                const current = (user.roles && user.roles.length) ? user.roles.join(', ') : user.role;
+                const newRoles = prompt(`Change roles for ${user.name} (comma separated):`, current);
+                if (newRoles) {
+                    const rolesArray = newRoles.split(',').map(r => r.trim().toLowerCase()).filter(r => ['admin','dispatcher','rider'].includes(r));
+                    if (rolesArray.length > 0) {
+                        updateUserRole(userId, rolesArray.join(','));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- enable multi-role authentication in AccessControl.gs
- include role arrays in user management data
- display multi-role badges and filtering on user management page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846114d202c8323b85060ea8a5ec5a7