### PR TITLE
Fix Assign Riders button navigation

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1387,8 +1387,7 @@ function navigateTo(page, params = {}) {
         if (currentEditingRequest && currentEditingRequest.requestId) {
             const requestId = currentEditingRequest.requestId;
             console.log('Navigating to assignments page for request:', requestId);
-            const params = new URLSearchParams({ page: 'assignments', requestId });
-            window.location.href = window.location.origin + window.location.pathname + '?' + params.toString();
+            navigateTo('assignments', { requestId });
         } else {
             showToast('No request selected or request ID is missing. Cannot navigate to assignments.');
             console.error('redirectToAssignmentPage called without a valid currentEditingRequest or requestId.');


### PR DESCRIPTION
## Summary
- update Requests page's Assign Riders button to reuse the global `navigateTo()` helper

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68461b5bfbd88323adf1c32bfba2e315