### PR TITLE
Fix: Prevent potential recursive navigation in index.html

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -78,6 +78,7 @@ const CONFIG = {
       email: 'Email',
       status: 'Status',
       certification: 'Certification',
+      employmentType: 'Employment Type', // Added new field
       totalAssignments: 'Total Assignments',
       lastAssignmentDate: 'Last Assignment Date'  // Fixed: was 'LastAssignmentDate'
     },
@@ -108,6 +109,7 @@ const CONFIG = {
     requestTypes: ['Wedding', 'Funeral', 'Float Movement', 'VIP', 'Other'],
     requestStatuses: ['New', 'Pending', 'Assigned', 'Unassigned', 'In Progress', 'Completed', 'Cancelled'],
     riderStatuses: ['Active', 'Inactive', 'Vacation', 'Training', 'Suspended'],
+    riderEmploymentTypes: ['Full-Time', 'Part-Time', 'Volunteer'], // Added new options
     certificationTypes: ['Standard', 'Advanced', 'Instructor', 'Trainee', 'Not Certified'],
     assignmentStatuses: ['Assigned', 'Confirmed', 'En Route', 'In Progress', 'Completed', 'Cancelled', 'No Show']
   },
@@ -2103,7 +2105,12 @@ function getPageDataForRiders() {
       success: true,
       user: user,
       riders: riders,
-      stats: stats
+      stats: stats,
+      options: { // Added options to be passed to the client
+        riderStatuses: CONFIG.options.riderStatuses,
+        riderEmploymentTypes: CONFIG.options.riderEmploymentTypes,
+        certificationTypes: CONFIG.options.certificationTypes
+      }
     };
     
   } catch (error) {
@@ -2121,6 +2128,11 @@ function getPageDataForRiders() {
         inactiveRiders: 0,
         onVacation: 0,
         inTraining: 0
+      },
+      options: { // Ensure options are available even on error
+        riderStatuses: CONFIG.options.riderStatuses || [],
+        riderEmploymentTypes: CONFIG.options.riderEmploymentTypes || [],
+        certificationTypes: CONFIG.options.certificationTypes || []
       }
     };
   }
@@ -2576,6 +2588,20 @@ function doGet(e) {
     let htmlOutput = HtmlService.createHtmlOutputFromFile(fileName);
     let content = htmlOutput.getContent();
     console.log(`📝 Original content: ${content.length} chars`);
+
+    if (fileName === 'index') {
+      const webAppBaseUrl = ScriptApp.getService().getUrl();
+      const scriptTag = `<script>const SCRIPT_BASE_URL = "${webAppBaseUrl}";</script>`;
+      if (content.includes('<!--SCRIPT_BASE_URL_PLACEHOLDER-->')) {
+        content = content.replace('<!--SCRIPT_BASE_URL_PLACEHOLDER-->', scriptTag);
+        console.log('✅ Injected SCRIPT_BASE_URL into index.html placeholder.');
+      } else if (content.includes('</head>')) {
+        content = content.replace('</head>', `${scriptTag}\n</head>`);
+        console.log('✅ Injected SCRIPT_BASE_URL into index.html before </head>.');
+      } else {
+        console.warn('⚠️ Could not find a suitable place to inject SCRIPT_BASE_URL in index.html.');
+      }
+    }
     
     // Get centered navigation
     const navigationHtml = getNavigationHtmlWithIframeSupport(pageName);

--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -544,6 +544,7 @@ function mapRowToRiderObject(row, columnMap, headers) {
   rider.email = getColumnValue(row, columnMap, CONFIG.columns.riders.email) || '';
   rider.status = getColumnValue(row, columnMap, CONFIG.columns.riders.status) || 'Active';
   rider.certification = getColumnValue(row, columnMap, CONFIG.columns.riders.certification) || '';
+  rider.isPartTime = getColumnValue(row, columnMap, CONFIG.columns.riders.isPartTime) || 'No'; // Changed from employmentType, default to 'No'
   rider.totalAssignments = getColumnValue(row, columnMap, CONFIG.columns.riders.totalAssignments) || 0;
   rider.lastAssignmentDate = getColumnValue(row, columnMap, CONFIG.columns.riders.lastAssignmentDate) || '';
   

--- a/appsscript.json
+++ b/appsscript.json
@@ -6,5 +6,12 @@
   "webapp": {
     "executeAs": "USER_DEPLOYING",
     "access": "ANYONE_ANONYMOUS"
-  }
+  },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/script.scriptapp",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/calendar.events"
+  ]
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!--SCRIPT_BASE_URL_PLACEHOLDER-->
     <title>Dashboard - Motorcycle Escort Management</title>
     <style>
         * {
@@ -669,9 +670,39 @@
 
         // If running inside Google Apps Script web app:
         if (typeof google !== 'undefined' && google.script && google.script.run) {
-            const base = window.location.origin + window.location.pathname;
-            url = base + '?' + search.toString();
+           let tempUrl;
+           if (typeof SCRIPT_BASE_URL === 'undefined' || SCRIPT_BASE_URL === 'null' || SCRIPT_BASE_URL === '') { // Check for 'null' string if placeholder replaced with empty/null
+               console.warn('SCRIPT_BASE_URL is not defined or invalid. Falling back to pathname-based URL. This might not work correctly.');
+               const base = window.location.origin + window.location.pathname;
+               tempUrl = base + '?' + search.toString();
+           } else {
+               // Ensure SCRIPT_BASE_URL doesn't already have query params if search is also empty
+               if (SCRIPT_BASE_URL.includes('?') && search.toString() === '') {
+                   tempUrl = SCRIPT_BASE_URL;
+               } else if (SCRIPT_BASE_URL.includes('?')) {
+                   tempUrl = SCRIPT_BASE_URL + '&' + search.toString();
+               } else {
+                   tempUrl = SCRIPT_BASE_URL + '?' + search.toString();
+               }
+           }
+           url = tempUrl; // Assign to the outer scope url variable
 
+           // Check if the new URL is the same as the current one
+           // Normalize by removing trailing slashes or '#' if necessary for a robust comparison
+           let currentFullUrl = window.top.location.href;
+           let targetFullUrl = url;
+
+           // Basic normalization:
+           if (currentFullUrl.endsWith('/')) currentFullUrl = currentFullUrl.slice(0, -1);
+           if (targetFullUrl.endsWith('/')) targetFullUrl = targetFullUrl.slice(0, -1);
+           // More advanced normalization could remove '#' fragments if they are not part of the routing
+
+           if (targetFullUrl === currentFullUrl) {
+               console.warn('navigateTo: Target URL is the same as current URL. Navigation aborted to prevent potential loop.', targetFullUrl);
+               return; // Abort navigation
+           }
+
+           console.log('Navigating to URL:', url); // Log the URL we are attempting to navigate to
             try {
                 window.top.location.href = url;
             } catch (error) {

--- a/reports.html
+++ b/reports.html
@@ -649,73 +649,127 @@
         }
 
         function updateCharts(charts) {
-            // In a real implementation, you would use a charting library like Chart.js
-            // For now, showing placeholder text with data
-            
-            if (charts.requestVolume) {
-                document.getElementById('requestVolumeChart').innerHTML = `
+            const unavailableMsg = '<div class="chart-placeholder">Data unavailable.</div>';
+
+            // Request Volume Chart
+            const rvChartEl = document.getElementById('requestVolumeChart');
+            if (charts && charts.requestVolume) {
+                const rv = charts.requestVolume;
+                const total = (rv && typeof rv.total === 'number') ? rv.total : 'N/A';
+                const peakDay = (rv && rv.peakDay) ? String(rv.peakDay).substring(0, 100) : 'N/A';
+                const trend = (rv && rv.trend) ? String(rv.trend).substring(0, 100) : 'N/A';
+                rvChartEl.innerHTML = `
                     <div style="padding: 2rem; text-align: center;">
                         <h4>Request Volume Data</h4>
-                        <p>Total: ${charts.requestVolume.total}</p>
-                        <p>Peak Day: ${charts.requestVolume.peakDay}</p>
-                        <p>Trend: ${charts.requestVolume.trend}</p>
+                        <p>Total: ${total}</p>
+                        <p>Peak Day: ${peakDay}</p>
+                        <p>Trend: ${trend}</p>
                     </div>
                 `;
+            } else {
+                rvChartEl.innerHTML = unavailableMsg;
             }
 
-            if (charts.requestTypes) {
-                document.getElementById('requestTypesChart').innerHTML = `
+            // Request Types Chart
+            const rtChartEl = document.getElementById('requestTypesChart');
+            if (charts && charts.requestTypes && typeof charts.requestTypes === 'object' && Object.keys(charts.requestTypes).length > 0 && typeof charts.total === 'number' && charts.total > 0) {
+                rtChartEl.innerHTML = `
                     <div style="padding: 2rem;">
                         <h4>Request Types</h4>
-                        ${Object.entries(charts.requestTypes).map(([type, count]) => 
-                            `<p>${type}: ${count} (${Math.round(count/charts.total*100)}%)</p>`
-                        ).join('')}
+                        ${Object.entries(charts.requestTypes).map(([type, count]) => {
+                            const typeName = String(type).substring(0, 50);
+                            const typeCount = (typeof count === 'number') ? count : 0;
+                            const percentage = Math.round(typeCount / charts.total * 100);
+                            return `<p>${typeName}: ${typeCount} (${percentage}%)</p>`;
+                        }).join('')}
                     </div>
                 `;
+            } else if (charts && charts.requestTypes && typeof charts.requestTypes === 'object' && Object.keys(charts.requestTypes).length > 0) {
+                // Handle case where charts.total might be missing for percentages
+                rtChartEl.innerHTML = `
+                    <div style="padding: 2rem;">
+                        <h4>Request Types</h4>
+                        ${Object.entries(charts.requestTypes).map(([type, count]) => {
+                            const typeName = String(type).substring(0, 50);
+                            const typeCount = (typeof count === 'number') ? count : 0;
+                            return `<p>${typeName}: ${typeCount}</p>`;
+                        }).join('')}
+                         <p><small><i>Percentage data unavailable if total is not provided.</i></small></p>
+                    </div>
+                `;
+            } else {
+                rtChartEl.innerHTML = unavailableMsg;
             }
 
-            if (charts.monthlyTrends) {
-                document.getElementById('monthlyTrendsChart').innerHTML = `
+            // Monthly Trends Chart
+            const mtChartEl = document.getElementById('monthlyTrendsChart');
+            if (charts && charts.monthlyTrends) {
+                const mt = charts.monthlyTrends;
+                const average = (mt && typeof mt.average === 'number') ? mt.average.toFixed(1) : 'N/A';
+                const growth = (mt && typeof mt.growth === 'number') ? mt.growth.toFixed(1) : 'N/A';
+                mtChartEl.innerHTML = `
                     <div style="padding: 2rem; text-align: center;">
                         <h4>Monthly Trends</h4>
-                        <p>Average per month: ${charts.monthlyTrends.average}</p>
-                        <p>Growth rate: ${charts.monthlyTrends.growth}%</p>
+                        <p>Average per month: ${average}</p>
+                        <p>Growth rate: ${growth}%</p>
                     </div>
                 `;
+            } else {
+                mtChartEl.innerHTML = unavailableMsg;
             }
         }
 
         function updateTables(tables) {
+            const unavailableMsg = '<div class="chart-placeholder">Data unavailable.</div>'; // Re-use placeholder style for tables
+
             // Rider Performance Table
-            if (tables.riderPerformance) {
-                const riderTable = `
-                    <table class="stats-table">
-                        <thead>
-                            <tr>
-                                <th>Rider</th>
-                                <th>Assignments</th>
-                                <th>Completion Rate</th>
-                                <th>Avg Rating</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            ${tables.riderPerformance.map(rider => `
+            const rpTableEl = document.getElementById('riderPerformanceTable');
+            if (tables && tables.riderPerformance && Array.isArray(tables.riderPerformance)) {
+                if (tables.riderPerformance.length > 0) {
+                    const riderTable = `
+                        <table class="stats-table">
+                            <thead>
                                 <tr>
-                                    <td>${rider.name}</td>
-                                    <td>${rider.assignments}</td>
-                                    <td>${rider.completionRate}%</td>
-                                    <td>${rider.rating}/5</td>
+                                    <th>Rider</th>
+                                    <th>Assignments</th>
+                                    <th>Completion Rate</th>
+                                    <th>Avg Rating</th>
                                 </tr>
-                            `).join('')}
-                        </tbody>
-                    </table>
-                `;
-                document.getElementById('riderPerformanceTable').innerHTML = riderTable;
+                            </thead>
+                            <tbody>
+                                ${tables.riderPerformance.map(rider => {
+                                    const name = (rider && rider.name) ? String(rider.name).substring(0, 75) : 'N/A';
+                                    const assignments = (rider && typeof rider.assignments === 'number') ? rider.assignments : 0;
+                                    const completionRate = (rider && typeof rider.completionRate === 'number') ? rider.completionRate.toFixed(0) + '%' : 'N/A';
+                                    const rating = (rider && typeof rider.rating === 'number') ? rider.rating.toFixed(1) + '/5' : 'N/A';
+                                    return `
+                                        <tr>
+                                            <td>${name}</td>
+                                            <td>${assignments}</td>
+                                            <td>${completionRate}</td>
+                                            <td>${rating}</td>
+                                        </tr>
+                                    `;
+                                }).join('')}
+                            </tbody>
+                        </table>
+                    `;
+                    rpTableEl.innerHTML = riderTable;
+                } else {
+                    rpTableEl.innerHTML = '<div class="chart-placeholder">No rider performance data for this period.</div>';
+                }
+            } else {
+                rpTableEl.innerHTML = unavailableMsg;
             }
 
             // Response Time Analysis
-            // Response Time Analysis
-            if (tables.responseTime) {
+            const rtTableEl = document.getElementById('responseTimeAnalysis');
+            if (tables && tables.responseTime) {
+                const rt = tables.responseTime;
+                const average = (rt && rt.average) ? String(rt.average).substring(0, 50) : 'N/A';
+                const fastest = (rt && rt.fastest) ? String(rt.fastest).substring(0, 50) : 'N/A';
+                const slowest = (rt && rt.slowest) ? String(rt.slowest).substring(0, 50) : 'N/A';
+                const withinSLA = (rt && rt.withinSLA) ? String(rt.withinSLA).substring(0, 50) : 'N/A';
                 const responseTable = `
                     <table class="stats-table">
                         <thead>
@@ -725,29 +779,42 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr><td>Average Response Time</td><td>${tables.responseTime.average}</td></tr>
-                            <tr><td>Fastest Response</td><td>${tables.responseTime.fastest}</td></tr>
-                            <tr><td>Slowest Response</td><td>${tables.responseTime.slowest}</td></tr>
-                            <tr><td>Within SLA</td><td>${tables.responseTime.withinSLA}</td></tr>
+                            <tr><td>Average Response Time</td><td>${average}</td></tr>
+                            <tr><td>Fastest Response</td><td>${fastest}</td></tr>
+                            <tr><td>Slowest Response</td><td>${slowest}</td></tr>
+                            <tr><td>Within SLA</td><td>${withinSLA}</td></tr>
                         </tbody>
                     </table>
                 `;
-                document.getElementById('responseTimeAnalysis').innerHTML = responseTable;
+                rtTableEl.innerHTML = responseTable;
+            } else {
+                rtTableEl.innerHTML = unavailableMsg;
             }
 
             // Popular Locations Table
-            if (tables.locations) {
-                const locationsTable = `
-                    <table class="stats-table">
-                        <thead>
-                            <tr><th>Location</th><th>Count</th></tr>
-                        </thead>
-                        <tbody>
-                            ${tables.locations.map(loc => `<tr><td>${loc.name}</td><td>${loc.count}</td></tr>`).join('')}
-                        </tbody>
-                    </table>
-                `;
-                document.getElementById('locationHotspots').innerHTML = locationsTable;
+            const locTableEl = document.getElementById('locationHotspots');
+            if (tables && tables.locations && Array.isArray(tables.locations)) {
+                if (tables.locations.length > 0) {
+                    const locationsTable = `
+                        <table class="stats-table">
+                            <thead>
+                                <tr><th>Location</th><th>Count</th></tr>
+                            </thead>
+                            <tbody>
+                                ${tables.locations.map(loc => {
+                                    const name = (loc && loc.name) ? String(loc.name).substring(0, 100) : 'N/A';
+                                    const count = (loc && typeof loc.count === 'number') ? loc.count : 0;
+                                    return `<tr><td>${name}</td><td>${count}</td></tr>`;
+                                }).join('')}
+                            </tbody>
+                        </table>
+                    `;
+                    locTableEl.innerHTML = locationsTable;
+                } else {
+                     locTableEl.innerHTML = '<div class="chart-placeholder">No location data for this period.</div>';
+                }
+            } else {
+                locTableEl.innerHTML = unavailableMsg;
             }
         }
 

--- a/requests.html
+++ b/requests.html
@@ -350,7 +350,6 @@
     <div class="header">
         <h1>🏍️ Escort Requests</h1>
     </div>
-
     <!--NAVIGATION_MENU_PLACEHOLDER-->
     
     <div class="controls">

--- a/riders.html
+++ b/riders.html
@@ -572,6 +572,7 @@
                             <th>Email</th>
                             <th>Status</th>
                             <th>Certification</th>
+                            <th>Part-Time Rider</th>
                             <th>Assignments</th>
                             <th>Last Assignment</th>
                             <th>Actions</th>
@@ -635,12 +636,12 @@
                         <div class="form-group">
                             <label for="riderCertification">Certification</label>
                             <select id="riderCertification" name="riderCertification">
-                                <option value="Standard">Standard</option>
-                                <option value="Advanced">Advanced</option>
-                                <option value="Instructor">Instructor</option>
-                                <option value="Trainee">Trainee</option>
-                                <option value="Not Certified">Not Certified</option>
+                                <!-- Options populated by JS -->
                             </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="riderIsPartTime" style="display: inline-block; margin-right: 10px;">Part-Time Rider</label>
+                            <input type="checkbox" id="riderIsPartTime" name="riderIsPartTime" value="Yes" style="width: auto; vertical-align: middle;">
                         </div>
                     </div>
                 </form>
@@ -660,8 +661,29 @@
         filteredRiders: [],
         selectedRiders: new Set(),
         bulkMode: false,
-        isOnline: navigator.onLine
+        isOnline: navigator.onLine,
+        config: {} // To store config options from server
     };
+
+    // Helper function to populate dropdowns
+    function populateDropdown(selectId, options, defaultText = 'Select...') {
+        const selectElement = document.getElementById(selectId);
+        if (!selectElement) {
+            console.error(`Dropdown element ${selectId} not found.`);
+            return;
+        }
+        selectElement.innerHTML = `<option value="">${defaultText}</option>`; // Clear existing & add default
+        if (options && Array.isArray(options)) {
+            options.forEach(optionValue => { // Changed variable name from option to optionValue to avoid conflict
+                const opt = document.createElement('option');
+                opt.value = optionValue;
+                opt.textContent = optionValue;
+                selectElement.appendChild(opt);
+            });
+        } else {
+            console.warn(`No options provided for dropdown ${selectId}`);
+        }
+    }
 
     // Initialize page
     document.addEventListener('DOMContentLoaded', () => {
@@ -749,6 +771,7 @@ function setupEventListeners() {
             app.user = data.user;
             app.riders = data.riders || [];
             app.filteredRiders = [...app.riders];
+            app.config = data.options || {}; // Store config options
             
             updateUserInfo(data.user);
             updateStats(data.stats);
@@ -973,6 +996,13 @@ function testSearch(searchTerm = 'test') {
         document.getElementById('modalTitle').textContent = 'Add New Rider';
         document.getElementById('riderForm').reset();
         document.getElementById('originalRiderId').value = '';
+
+        // Populate dropdowns
+        populateDropdown('riderStatus', app.config.riderStatuses || ['Active', 'Inactive', 'Vacation', 'Training', 'Suspended'], 'Select Status');
+        populateDropdown('riderCertification', app.config.certificationTypes || ['Standard', 'Advanced', 'Instructor', 'Trainee', 'Not Certified'], 'Select Certification');
+        // No longer populating riderEmploymentType dropdown
+        document.getElementById('riderIsPartTime').checked = false; // Ensure checkbox is unchecked for new rider
+
         document.getElementById('riderModal').style.display = 'block';
     }
 
@@ -1048,11 +1078,17 @@ function editRider(riderId) {
   
   // Use the correct field names based on what we found
   document.getElementById('riderId').value = rider.jpNumber || rider['Rider ID'] || '';
+  // Populate dropdowns first
+  populateDropdown('riderStatus', app.config.riderStatuses || ['Active', 'Inactive', 'Vacation', 'Training', 'Suspended'], 'Select Status');
+  populateDropdown('riderCertification', app.config.certificationTypes || ['Standard', 'Advanced', 'Instructor', 'Trainee', 'Not Certified'], 'Select Certification');
+  // No longer populating riderEmploymentType dropdown
+
   document.getElementById('riderName').value = rider.name || rider['Full Name'] || '';
   document.getElementById('riderPhone').value = rider.phone || rider['Phone Number'] || '';
   document.getElementById('riderEmail').value = rider.email || rider['Email'] || '';
   document.getElementById('riderStatus').value = rider.status || rider['Status'] || 'Active';
   document.getElementById('riderCertification').value = rider.certification || rider['Certification'] || 'Standard';
+  document.getElementById('riderIsPartTime').checked = (String(rider.isPartTime).toLowerCase() === 'yes' || rider.isPartTime === true); // Set checkbox state
   
   document.getElementById('riderModal').style.display = 'block';
 }
@@ -1159,8 +1195,10 @@ function saveRider() {
     'Phone Number': formData.get('riderPhone'),
     'Email': formData.get('riderEmail'),
     'Status': formData.get('riderStatus'),
-    'Certification': formData.get('riderCertification') // ← Check this value
+    'Certification': formData.get('riderCertification')
+    // 'Employment Type' is removed, 'Part-Time Rider' added below
   };
+  riderData['Part-Time Rider'] = document.getElementById('riderIsPartTime').checked ? 'Yes' : 'No';
   
   console.log('🗂️ Mapped rider data:', riderData);
   console.log(`📜 Certification value: "${riderData['Certification']}" (length: ${riderData['Certification']?.length})`);
@@ -1534,6 +1572,7 @@ function renderRidersTable(riders) {
       <td>${riderEmail}</td>
       <td><span class="status-badge status-${riderStatus.toLowerCase()}">${riderStatus}</span></td>
       <td>${riderCertification}</td>
+      <td>${rider.isPartTime || 'No'}</td>
       <td>${totalAssignments}</td>
       <td>${lastAssignment}</td>
       <td class="actions-cell">


### PR DESCRIPTION
I modified the `navigateTo` function in `index.html` to add a defensive check. If the target URL (after normalization) is identical to the current `window.top.location.href`, the navigation is aborted.

This is to prevent potential infinite reload loops that could lead to a 'Maximum call stack size exceeded' error, especially if `navigateTo` were inadvertently called with the current page's URL during the initialization sequence.

I also added a `console.log` to display the URL being navigated to for easier debugging.