### PR TITLE
Fix blank user management page

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -3002,6 +3002,13 @@ function createSimpleUserManagementPage() {
 }
 
 /**
+ * Fallback dashboard if user-management.html is missing
+ */
+function createUserManagementDashboard() {
+  return createSimpleUserManagementPage();
+}
+
+/**
  * Simple navigation for testing
  */
 function getSimpleNavigation(currentPage, user) {


### PR DESCRIPTION
## Summary
- add `createUserManagementDashboard` fallback function
- ensure user management page loads if HTML file is missing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed733d70832398331411d7d7c66a