### PR TITLE
Add notifications to dashboards

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1691,6 +1691,30 @@ function getNotificationHistory() {
   }
 }
 
+/**
+ * Wrapper for admin dashboard notifications
+ */
+function getSystemNotifications() {
+  try {
+    return getNotificationHistory().slice(0, 10);
+  } catch (error) {
+    logError('Error getting system notifications', error);
+    return [];
+  }
+}
+
+/**
+ * Wrapper for dispatcher dashboard notifications
+ */
+function getDispatchNotifications() {
+  try {
+    return getNotificationHistory().slice(0, 10);
+  } catch (error) {
+    logError('Error getting dispatch notifications', error);
+    return [];
+  }
+}
+
 // ===== REPORTS FUNCTIONS =====
 /**
  * Generates report data based on filters.
@@ -2038,13 +2062,17 @@ function getPageDataForDashboard() {
     const stats = getDashboardStats();
     const recentRequests = getRecentRequestsForWebApp(5);
     const upcomingAssignments = getUpcomingAssignmentsForWebApp(5);
+    const notifications = (typeof getNotificationHistory === 'function')
+      ? getNotificationHistory().slice(0, 10)
+      : [];
     
     return {
       success: true,
       user: user,
       stats: stats,
       recentRequests: recentRequests,
-      upcomingAssignments: upcomingAssignments
+      upcomingAssignments: upcomingAssignments,
+      notifications: notifications
     };
   } catch (error) {
     logError('Error in getPageDataForDashboard', error);

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -471,6 +471,19 @@
                 </div>
             </div>
         </div>
+
+        <!-- Recent Notifications -->
+        <div class="recent-activity">
+            <div class="activity-title">
+                🔔 Recent Notifications
+            </div>
+            <div class="activity-list" id="notificationList">
+                <div class="activity-item">
+                    <div class="activity-description">Loading notifications...</div>
+                    <div class="activity-time">--</div>
+                </div>
+            </div>
+        </div>
     </div>
 
     <script>
@@ -478,7 +491,8 @@
         document.addEventListener('DOMContentLoaded', function() {
             loadAdminDashboardData();
             loadRecentActivity();
-            
+            loadRecentNotifications();
+
             // Auto-refresh every 30 seconds
             setInterval(loadAdminDashboardData, 30000);
         });
@@ -528,6 +542,17 @@
             }
         }
 
+        function loadRecentNotifications() {
+            if (typeof google !== 'undefined' && google.script && google.script.run) {
+                google.script.run
+                    .withSuccessHandler(updateRecentNotifications)
+                    .withFailureHandler(handleActivityError)
+                    .getNotificationHistory();
+            } else {
+                updateRecentNotifications(getDemoNotifications());
+            }
+        }
+
         function updateRecentActivity(activities) {
             const activityList = document.getElementById('activityList');
             
@@ -542,6 +567,26 @@
                 activityList.innerHTML = `
                     <div class="activity-item">
                         <div class="activity-description">No recent activity</div>
+                        <div class="activity-time">--</div>
+                    </div>
+                `;
+            }
+        }
+
+        function updateRecentNotifications(notifications) {
+            const container = document.getElementById('notificationList');
+
+            if (notifications && notifications.length > 0) {
+                container.innerHTML = notifications.map(n => `
+                    <div class="activity-item">
+                        <div class="activity-description">${n.recipient} (${n.type})</div>
+                        <div class="activity-time">${new Date(n.timestamp).toLocaleString()}</div>
+                    </div>
+                `).join('');
+            } else {
+                container.innerHTML = `
+                    <div class="activity-item">
+                        <div class="activity-description">No notifications</div>
                         <div class="activity-time">--</div>
                     </div>
                 `;
@@ -738,6 +783,13 @@ function displaySystemLogs(logs) {
                 { description: 'Rider John Smith completed assignment E-123-25', time: '15 min ago' },
                 { description: 'System backup completed successfully', time: '1 hour ago' },
                 { description: 'New user registration pending approval', time: '2 hours ago' }
+            ];
+        }
+
+        function getDemoNotifications() {
+            return [
+                { recipient: 'John Doe', type: 'SMS', timestamp: new Date().toISOString(), requestId: 'REQ-1' },
+                { recipient: 'Jane Smith', type: 'Email', timestamp: new Date().toISOString(), requestId: 'REQ-2' }
             ];
         }
 

--- a/index.html
+++ b/index.html
@@ -416,6 +416,14 @@
                     </button>
                 </div>
             </div>
+
+            <!-- Recent Notifications -->
+            <div class="card">
+                <h3>🔔 Recent Notifications</h3>
+                <div class="request-list" id="recentNotificationsList">
+                    <div class="loading">Loading notifications...</div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -472,6 +480,7 @@
             updateStats(data.stats);
             updateRecentRequests(data.recentRequests);
             updateUpcomingAssignments(data.upcomingAssignments);
+            updateNotifications(data.notifications);
         } else {
             console.error('❌ Failed to load dashboard data or success flag false:', data ? data.error : 'No data returned');
             handleDashboardDataFailure(data || { message: "Received success:false or no data." });
@@ -669,6 +678,42 @@
         }
     }
 
+    function updateNotifications(notifications) {
+        console.log('🔔 Updating notifications:', notifications);
+        const container = document.getElementById('recentNotificationsList');
+
+        if (!container) {
+            console.error('❌ Notifications container not found');
+            return;
+        }
+
+        if (!notifications || notifications.length === 0) {
+            container.innerHTML = `
+                <div class="empty-message">
+                    <p>No recent notifications</p>
+                </div>
+            `;
+            return;
+        }
+
+        try {
+            container.innerHTML = notifications.map(n => `
+                <div class="request-item">
+                    <div class="request-info">
+                        <h4>${n.recipient}</h4>
+                        <div class="request-meta">${n.type} • ${new Date(n.timestamp).toLocaleString()}</div>
+                    </div>
+                    <span class="status-badge">${n.requestId}</span>
+                </div>
+            `).join('');
+
+            console.log('✅ Notifications updated successfully');
+        } catch (error) {
+            console.error('❌ Error updating notifications HTML:', error);
+            container.innerHTML = '<div class="empty-message"><p>Error loading notifications</p></div>';
+        }
+    }
+
     function setFallbackValues() {
         console.log('⚠️ Setting fallback values due to loading timeout or errors');
 
@@ -681,6 +726,7 @@
 
         updateRecentRequests([]);
         updateUpcomingAssignments([]);
+        updateNotifications([]);
 
         showMessage('Some dashboard data may not be current. Please try refreshing.', 'warning');
     }
@@ -763,6 +809,7 @@
 
         document.getElementById('recentRequestsList').innerHTML = '<div class="loading">Loading recent requests...</div>';
         document.getElementById('upcomingAssignmentsList').innerHTML = '<div class="loading">Loading assignments...</div>';
+        document.getElementById('recentNotificationsList').innerHTML = '<div class="loading">Loading notifications...</div>';
 
         initializeDashboard();
 


### PR DESCRIPTION
## Summary
- show recent notifications on dispatcher and admin dashboards
- add server functions to supply notification data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847557c6c688323bf6167d784b3aab3