### PR TITLE
Fix navigation default links

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -1,10 +1,11 @@
 <nav class="navigation">
-    <a href="?page=dashboard" class="nav-button" id="nav-dashboard" data-page="dashboard">📊 Dashboard</a>
-    <a href="?page=requests" class="nav-button" id="nav-requests" data-page="requests">📋 Requests</a>
-    <a href="?page=assignments" class="nav-button" id="nav-assignments" data-page="assignments">🏍️ Assignments</a>
-    <a href="?page=riders" class="nav-button" id="nav-riders" data-page="riders">👥 Riders</a>
-    <a href="?page=notifications" class="nav-button" id="nav-notifications" data-page="notifications">📱 Notifications</a>
-    <a href="?page=reports" class="nav-button" id="nav-reports" data-page="reports">📊 Reports</a>
+    <!-- Default to local HTML files so navigation works without JavaScript -->
+    <a href="index.html" class="nav-button" id="nav-dashboard" data-page="dashboard">📊 Dashboard</a>
+    <a href="requests.html" class="nav-button" id="nav-requests" data-page="requests">📋 Requests</a>
+    <a href="assignments.html" class="nav-button" id="nav-assignments" data-page="assignments">🏍️ Assignments</a>
+    <a href="riders.html" class="nav-button" id="nav-riders" data-page="riders">👥 Riders</a>
+    <a href="notifications.html" class="nav-button" id="nav-notifications" data-page="notifications">📱 Notifications</a>
+    <a href="reports.html" class="nav-button" id="nav-reports" data-page="reports">📊 Reports</a>
 </nav>
 <script>
   (function() {


### PR DESCRIPTION
## Summary
- set default navigation links to actual HTML files so navigation works even when scripts fail

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68475fd946348323bd61d5d4921babe6