### PR TITLE
Fix assign riders navigation

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1392,8 +1392,7 @@ function navigateTo(page, params = {}) {
         if (currentEditingRequest && currentEditingRequest.requestId) {
             const requestId = currentEditingRequest.requestId;
             console.log('Navigating to assignments page for request:', requestId);
-            const params = new URLSearchParams({ page: 'assignments', requestId });
-            window.location.href = window.location.origin + window.location.pathname + '?' + params.toString();
+            navigateTo('assignments', { requestId: requestId });
         } else {
             showToast('No request selected or request ID is missing. Cannot navigate to assignments.');
             console.error('redirectToAssignmentPage called without a valid currentEditingRequest or requestId.');


### PR DESCRIPTION
## Summary
- use shared `navigateTo` helper when opening Assignments from Requests page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847605fabf08323a2c69d97b1e1b8f6