### PR TITLE
Add assignment order display

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -1694,6 +1694,14 @@ function getActiveRidersForAssignments() {
       'Email',
       'Email Address'
     ];
+
+    const partTimeColumns = [
+      CONFIG.columns.riders.partTime,
+      'Part Time',
+      'Part-Time',
+      'Part Time Rider',
+      'PartTime'
+    ];
     
     // Find the best column matches
     const getColumnIndex = (possibleNames) => {
@@ -1710,6 +1718,7 @@ function getActiveRidersForAssignments() {
     const jpNumberColIndex = getColumnIndex(jpNumberColumns);
     const phoneColIndex = getColumnIndex(phoneColumns);
     const emailColIndex = getColumnIndex(emailColumns);
+    const partTimeColIndex = getColumnIndex(partTimeColumns);
     
     console.log('🔍 Column detection results:');
     console.log(`  Name column: index ${nameColIndex} (${nameColumns.find(n => columnMap[n] !== undefined) || 'NOT FOUND'})`);
@@ -1728,7 +1737,7 @@ function getActiveRidersForAssignments() {
         const row = ridersData.data[i];
         
         // Get rider data with enhanced fallback logic
-        let riderName, status, jpNumber, phone, email;
+        let riderName, status, jpNumber, phone, email, partTime;
         
         if (usePositionalFallback) {
           // Assume standard order: ID, Name, Phone, Email, Status, ...
@@ -1737,12 +1746,14 @@ function getActiveRidersForAssignments() {
           phone = row[2] || '';
           email = row[3] || '';
           status = row[4] || 'Active'; // Default to Active
+          partTime = row[5] || 'No';
         } else {
           riderName = nameColIndex >= 0 ? row[nameColIndex] : (row[1] || '');
           status = statusColIndex >= 0 ? row[statusColIndex] : 'Active';
           jpNumber = jpNumberColIndex >= 0 ? row[jpNumberColIndex] : (row[0] || '');
           phone = phoneColIndex >= 0 ? row[phoneColIndex] : (row[2] || '');
           email = emailColIndex >= 0 ? row[emailColIndex] : (row[3] || '');
+          partTime = partTimeColIndex >= 0 ? row[partTimeColIndex] : (row[5] || 'No');
         }
         
         // Debug first few riders
@@ -1751,6 +1762,7 @@ function getActiveRidersForAssignments() {
             name: riderName,
             jpNumber: jpNumber,
             status: status,
+            partTime: partTime,
             phone: phone,
             hasValidName: !!(riderName && String(riderName).trim().length > 0)
           });
@@ -1792,7 +1804,8 @@ function getActiveRidersForAssignments() {
           phone: phone ? String(phone).trim() : '555-0000',
           email: email ? String(email).trim() : '',
           carrier: 'Unknown',
-          status: 'Available'
+          status: 'Available',
+          partTime: partTime ? String(partTime).trim() : 'No'
         });
         
         if (i < 3) {

--- a/assignments.html
+++ b/assignments.html
@@ -379,6 +379,19 @@
             border-left: 4px solid #f39c12;
         }
 
+        .assignment-order {
+            background: #f0f8ff;
+            border-radius: 10px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            border-left: 4px solid #3498db;
+        }
+
+        .assignment-order ul {
+            padding-left: 1.25rem;
+            list-style: disc;
+        }
+
         .current-assigned ul {
             margin: 0;
             padding-left: 1.2rem;
@@ -580,6 +593,7 @@
     var preselectAttempted = false;
     /** Map of rider name to availability status */
     var riderAvailability = {}; // e.g., {"John Doe": "Unavailable"}
+    var remainingAvailabilityCallbacks = 0;
     /** @type {AppStateAssignments} */
     var app = {
         user: null,
@@ -1029,6 +1043,7 @@ if (!document.getElementById('debug-styles')) {
 
         activeRiders = Array.isArray(data) ? data : [];
         console.log('📊 Stored riders count:', activeRiders.length);
+        updateAssignmentOrder();
     }
 
     /**
@@ -1332,6 +1347,10 @@ function selectRequestById(requestId) {
             '<div id="assignedRidersList">' + assignedListHtml + '</div>' +
 
             '</div>' +
+            '<div class="assignment-order">' +
+            '<h4>Assignment Order</h4>' +
+            '<ul id="assignmentOrderList"><li>Loading...</li></ul>' +
+            '</div>' +
             '<div class="assignment-summary">' +
             '<div>Selected Riders: <span class="selected-count" id="selectedCount">' + selectedRiders.size + '</span> / ' + selectedRequest.ridersNeeded + '</div>' +
             '</div>' +
@@ -1356,6 +1375,7 @@ function selectRequestById(requestId) {
             '</div>';
 
         updateSelectedCount();
+        updateAssignmentOrder();
         fetchRiderAvailabilityForRequest();
     }
 
@@ -1467,6 +1487,31 @@ function updateAssignedRidersList() {
     listContainer.innerHTML = html;
 }
 
+function updateAssignmentOrder() {
+    var orderContainer = document.getElementById('assignmentOrderList');
+    if (!orderContainer) return;
+
+    var list = activeRiders.filter(function(r) {
+        return String(r.partTime || 'No').toLowerCase() !== 'yes';
+    });
+
+    list.sort(function(a, b) { return a.name.localeCompare(b.name); });
+
+    list = list.filter(function(r) {
+        var avail = riderAvailability[r.name];
+        return !avail || avail === 'Available';
+    });
+
+    var nextFive = list.slice(0, 5);
+    if (nextFive.length === 0) {
+        orderContainer.innerHTML = '<li>No available riders</li>';
+    } else {
+        orderContainer.innerHTML = nextFive.map(function(r) {
+            return '<li>' + r.name + '</li>';
+        }).join('');
+    }
+}
+
     /**
      * Fetch availability/conflict status for each rider for the selected request.
      * Updates riderAvailability map and the UI accordingly.
@@ -1476,6 +1521,11 @@ function updateAssignedRidersList() {
         if (!selectedRequest) return;
 
         riderAvailability = {};
+        remainingAvailabilityCallbacks = activeRiders.length;
+        if (remainingAvailabilityCallbacks === 0) {
+            updateAssignmentOrder();
+            return;
+        }
 
         activeRiders.forEach(function(rider) {
             if (typeof google !== 'undefined' && google.script && google.script.run) {
@@ -1483,11 +1533,18 @@ function updateAssignedRidersList() {
                     .withSuccessHandler(function(available) {
                         riderAvailability[rider.name] = available ? 'Available' : 'Unavailable';
                         updateSingleRiderAvailability(rider.name);
+                        remainingAvailabilityCallbacks--;
+                        if (remainingAvailabilityCallbacks === 0) updateAssignmentOrder();
                     })
                     .withFailureHandler(function(err) {
                         console.error('Availability check failed for', rider.name, err);
+                        remainingAvailabilityCallbacks--;
+                        if (remainingAvailabilityCallbacks === 0) updateAssignmentOrder();
                     })
                     .isRiderAvailable(rider.name, selectedRequest.eventDate, selectedRequest.startTime);
+            } else {
+                remainingAvailabilityCallbacks--;
+                if (remainingAvailabilityCallbacks === 0) updateAssignmentOrder();
             }
         });
     }


### PR DESCRIPTION
## Summary
- include `partTime` info in active riders API
- show assignment order list on assignment page
- compute next five available full-time riders alphabetically

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68478b4117388323b8674515e816346f