### PR TITLE
Fix rider unassign highlight

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -1445,6 +1445,9 @@ function selectRequestById(requestId) {
     function toggleRider(riderName) {
         if (selectedRiders.has(riderName)) {
             selectedRiders.delete(riderName);
+            // Immediately mark the rider as available again
+            riderAvailability[riderName] = 'Available';
+            updateSingleRiderAvailability(riderName);
         } else {
             selectedRiders.add(riderName);
         }


### PR DESCRIPTION
## Summary
- update toggle logic so unassigning a rider marks them available immediately

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684831c107d8832383f05d742f2b4dab