### PR TITLE
Allow unassigning all riders from a request

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -3155,8 +3155,8 @@ function processAssignmentAndPopulate(requestId, selectedRiders) {
     console.log(`🏍️ Starting assignment process for request ${requestId} with ${selectedRiders.length} riders`);
     console.log('Selected riders:', JSON.stringify(selectedRiders, null, 2));
     
-    if (!requestId || !selectedRiders || selectedRiders.length === 0) {
-      throw new Error('Request ID and riders are required for assignment');
+    if (!requestId || !selectedRiders) {
+      throw new Error('Request ID is required for assignment');
     }
 
     // Validate that the request exists and get its details
@@ -3501,9 +3501,10 @@ function updateRequestWithAssignedRiders(requestId, riderNames) {
       requestsSheet.getRange(sheetRowNumber, ridersAssignedCol + 1).setValue(ridersText);
     }
 
-    // Update status to 'Assigned' if riders were assigned
-    if (statusCol !== undefined && riderNames.length > 0) {
-      requestsSheet.getRange(sheetRowNumber, statusCol + 1).setValue('Assigned');
+    // Update status based on whether riders were assigned
+    if (statusCol !== undefined) {
+      const newStatus = riderNames.length > 0 ? 'Assigned' : 'Unassigned';
+      requestsSheet.getRange(sheetRowNumber, statusCol + 1).setValue(newStatus);
     }
 
     // Update last modified timestamp

--- a/assignments.html
+++ b/assignments.html
@@ -1369,7 +1369,7 @@ function selectRequestById(requestId) {
             '</div>' +
             '</div>' +
             '<div class="assignment-actions">' +
-            '<button class="btn btn-success" onclick="saveAssignment()" ' + (selectedRiders.size === 0 ? 'disabled' : '') + '>' +
+            '<button class="btn btn-success" onclick="saveAssignment()">' +
             '💾 Save Assignment' +
             '</button>' +
             '<button class="btn btn-warning" onclick="clearAssignment()">' +
@@ -1480,8 +1480,8 @@ function updateSelectedCount() {
 
     var saveBtn = document.querySelector('.btn-success');
     if (saveBtn) {
-        saveBtn.disabled = selectedRiders.size === 0;
-        saveBtn.style.opacity = selectedRiders.size === 0 ? '0.5' : '1';
+        saveBtn.disabled = !selectedRequest;
+        saveBtn.style.opacity = !selectedRequest ? '0.5' : '1';
     }
 
     updateAssignedRidersList();
@@ -1626,8 +1626,8 @@ function updateAssignmentOrder() {
      * @return {void}
      */
     function saveAssignment() {
-        if (!selectedRequest || selectedRiders.size === 0) {
-            showError('Please select at least one rider');
+        if (!selectedRequest) {
+            showError('No request selected');
             return;
         }
 


### PR DESCRIPTION
## Summary
- enable `processAssignmentAndPopulate` to accept zero riders
- set request status to `Unassigned` when no riders are saved
- allow saving assignment with no riders via UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68483602a9248323bf67d96e4c65c3a6