### PR TITLE
Fix auth-setup access

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -1220,9 +1220,14 @@ function doGet(e) {
     if (!authCheck.allowed) {
       return createAccessDeniedPage(authCheck.reason, authenticatedUser);
     }
-    
+
     console.log(`📄 Loading page: ${pageName} for role: ${authenticatedUser.role}`);
-    
+
+    // special handling for the authentication setup page
+    if (pageName === 'auth-setup') {
+      return createAuthMappingPage();
+    }
+
     // Continue with your existing page loading logic...
     const fileName = getPageFileNameSafe(pageName, authenticatedUser.role);
     let htmlOutput = HtmlService.createHtmlOutputFromFile(fileName);

--- a/Code.gs
+++ b/Code.gs
@@ -4400,7 +4400,18 @@ function getDispatcherUsers() {
 // 🔒 Authorization Functions
 function checkPageAccess(pageName, user, rider) {
   const rolePermissions = {
-    admin: ['dashboard', 'requests', 'assignments', 'riders', 'notifications', 'reports', 'admin-schedule'],
+    admin: [
+      'dashboard',
+      'requests',
+      'assignments',
+      'riders',
+      'notifications',
+      'reports',
+      'admin-schedule',
+      // allow pages only accessible to admins
+      'user-management',
+      'auth-setup'
+    ],
     dispatcher: ['dashboard', 'requests', 'assignments', 'notifications', 'reports'],
     rider: ['dashboard', 'rider-schedule', 'my-assignments']
   };


### PR DESCRIPTION
## Summary
- permit admin pages `user-management` and `auth-setup`
- route `auth-setup` directly to `createAuthMappingPage`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f18b6c40c8323aa37adc9b4e313ad