### PR TITLE
Enable assigning from assignment order

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -392,6 +392,15 @@
             list-style: disc;
         }
 
+        .assignment-order li {
+            cursor: pointer;
+            transition: color 0.2s ease;
+        }
+
+        .assignment-order li:hover {
+            color: #27ae60;
+        }
+
         .priority-checkbox {
             margin-bottom: 1rem;
         }
@@ -1570,8 +1579,16 @@ function updateAssignmentOrder() {
         orderContainer.innerHTML = '<li>No available riders</li>';
     } else {
         orderContainer.innerHTML = nextFive.map(function(r) {
-            return '<li>' + r.name + '</li>';
+            return '<li class="order-rider" data-rider-name="' + r.name.replace(/"/g,'&quot;') + '">' + r.name + '</li>';
         }).join('');
+
+        var items = orderContainer.querySelectorAll('.order-rider');
+        for (var i = 0; i < items.length; i++) {
+            items[i].addEventListener('click', function() {
+                var riderName = this.dataset.riderName;
+                toggleRider(riderName);
+            });
+        }
     }
 }
     /**


### PR DESCRIPTION
## Summary
- add clickable styling for riders in the assignment order section
- support toggling rider selection directly from the assignment order list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f2c84fa748323a5d5950754247582