### PR TITLE
Fix assign riders redirect from request details

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1362,24 +1362,23 @@ function navigateTo(page, params = {}) {
     search.set('page', page);
     Object.keys(params).forEach(key => search.set(key, params[key]));
 
-    function openUrl(base) {
-        const url = base + '?' + search.toString();
-        try {
-            window.location.href = url;
-        } catch (error) {
-            try {
-                window.top.location.href = url;
-            } catch (topError) {
-                window.open(url, '_blank');
-            }
-        }
+    let base;
+    if (typeof google !== 'undefined' && google.script && google.script.run) {
+        base = window.location.origin + window.location.pathname;
+    } else {
+        base = page === 'dashboard' ? 'index.html' : page + '.html';
     }
 
-    if (typeof google !== 'undefined' && google.script && google.script.run) {
-        google.script.run.withSuccessHandler(openUrl).getWebAppUrl();
-    } else {
-        const base = page === 'dashboard' ? 'index.html' : page + '.html';
-        openUrl(base);
+    const url = base + (search.toString() ? '?' + search.toString() : '');
+
+    try {
+        window.location.href = url;
+    } catch (error) {
+        try {
+            window.top.location.href = url;
+        } catch (topError) {
+            window.open(url, '_blank');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- patch navigateTo logic in `requests.html` to use the current page URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f4996dd0483238664e6681d8125b5