### PR TITLE
Fix assign riders navigation

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1362,23 +1362,24 @@ function navigateTo(page, params = {}) {
     search.set('page', page);
     Object.keys(params).forEach(key => search.set(key, params[key]));
 
-    let base;
-    if (typeof google !== 'undefined' && google.script && google.script.run) {
-        base = window.location.origin + window.location.pathname;
-    } else {
-        base = page === 'dashboard' ? 'index.html' : page + '.html';
+    function openUrl(base) {
+        const url = base + '?' + search.toString();
+        try {
+            window.location.href = url;
+        } catch (error) {
+            try {
+                window.top.location.href = url;
+            } catch (topError) {
+                window.open(url, '_blank');
+            }
+        }
     }
 
-    const url = base + (search.toString() ? '?' + search.toString() : '');
-
-    try {
-        window.location.href = url;
-    } catch (error) {
-        try {
-            window.top.location.href = url;
-        } catch (topError) {
-            window.open(url, '_blank');
-        }
+    if (typeof google !== 'undefined' && google.script && google.script.run) {
+        google.script.run.withSuccessHandler(openUrl).getWebAppUrl();
+    } else {
+        const base = page === 'dashboard' ? 'index.html' : page + '.html';
+        openUrl(base);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure `navigateTo` uses `google.script.run` for base URL like other pages
- this restores working Assign Riders button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ff92cddb48323a4997b3223cdf6ad