### PR TITLE
Fix Assign Riders navigation fallback

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1376,7 +1376,13 @@ function navigateTo(page, params = {}) {
     }
 
     if (typeof google !== 'undefined' && google.script && google.script.run) {
-        google.script.run.withSuccessHandler(openUrl).getWebAppUrl();
+        google.script.run
+            .withSuccessHandler(openUrl)
+            .withFailureHandler(function() {
+                var fallbackBase = window.location.origin + window.location.pathname;
+                openUrl(fallbackBase);
+            })
+            .getWebAppUrl();
     } else {
         const base = page === 'dashboard' ? 'index.html' : page + '.html';
         openUrl(base);


### PR DESCRIPTION
## Summary
- fix navigation to assignments page when Apps Script call fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ffc5e263883239b2b0bcd612c1e9b