### PR TITLE
Add links to admin dashboard stats

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -366,19 +366,19 @@
 
         <!-- Main Stats Grid -->
         <div class="stats-grid">
-            <div class="stat-card requests">
+            <div class="stat-card requests" style="cursor:pointer" onclick="navigateStat('requests')">
                 <div class="stat-number" id="totalRequests">-</div>
                 <div class="stat-label">Total Requests</div>
             </div>
-            <div class="stat-card riders">
+            <div class="stat-card riders" style="cursor:pointer" onclick="navigateStat('riders')">
                 <div class="stat-number" id="totalRiders">-</div>
                 <div class="stat-label">Active Riders</div>
             </div>
-            <div class="stat-card assignments">
+            <div class="stat-card assignments" style="cursor:pointer" onclick="navigateStat('assignments')">
                 <div class="stat-number" id="totalAssignments">-</div>
                 <div class="stat-label">Assignments</div>
             </div>
-            <div class="stat-card system">
+            <div class="stat-card system" style="cursor:pointer" onclick="navigateStat('user-management')">
                 <div class="stat-number" id="systemUsers">-</div>
                 <div class="stat-label">System Users</div>
             </div>
@@ -612,6 +612,12 @@
         function openAuthSetup() {
             getDeployedUrl(function(baseUrl) {
                 window.open(baseUrl + '?page=auth-setup', '_blank');
+            });
+        }
+
+        function navigateStat(page) {
+            getDeployedUrl(function(baseUrl) {
+                window.open(baseUrl + '?page=' + page, '_top');
             });
         }
 


### PR DESCRIPTION
## Summary
- make stat blocks on admin dashboard clickable
- add helper function `navigateStat` to open desired page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685000140fd483239764d308b6ccd2bb