### PR TITLE
Add onInstall trigger for menu

### DIFF
--- a/Menu.gs
+++ b/Menu.gs
@@ -26,6 +26,16 @@ function onOpen() {
 }
 
 /**
+ * Installable trigger entry point to ensure the menu is created even when
+ * the script is newly added to a spreadsheet or reauthorized.
+ * @param {Event} e The install event.
+ * @return {void}
+ */
+function onInstall(e) {
+  onOpen(e);
+}
+
+/**
  * Creates the custom menu in the Google Sheet UI.
  * Provides access to various system functionalities like opening sidebars, refreshing data,
  * and triggering bulk notifications.


### PR DESCRIPTION
## Summary
- ensure `createMenu()` runs when the script is installed

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68507ce35d3883238c7a12852ac0bab3