### PR TITLE
Fix navigation history handling

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -35,20 +35,16 @@
     var url = link.dataset.url || link.getAttribute('href');
     if (!url || url === '#') return false;
     try {
-      window.location.href = url;
+      window.top.location.assign(url);
     } catch (e) {
-      try {
-        window.top.location.href = url;
-      } catch (err) {
-        window.open(url, '_top');
-      }
+      window.location.assign(url);
     }
     return false;
   }
 
   function navigateToPage(url) {
     if (url && url !== '#') {
-      window.location.href = url;
+      window.location.assign(url);
     }
   }
 </script>

--- a/index.html
+++ b/index.html
@@ -751,13 +751,9 @@
         }
 
         try {
-            window.location.href = url;
+            window.top.location.assign(url);
         } catch (error) {
-            try {
-                window.top.location.href = url;
-            } catch (topError) {
-                window.open(url, '_blank');
-            }
+            window.location.assign(url);
         }
     }
 

--- a/requests.html
+++ b/requests.html
@@ -1365,13 +1365,9 @@ function navigateTo(page, params = {}) {
     function openUrl(base) {
         const url = base + '?' + search.toString();
         try {
-            window.location.href = url;
+            window.top.location.assign(url);
         } catch (error) {
-            try {
-                window.top.location.href = url;
-            } catch (topError) {
-                window.open(url, '_blank');
-            }
+            window.location.assign(url);
         }
     }
 

--- a/riders.html
+++ b/riders.html
@@ -1903,13 +1903,9 @@ function navigateTo(page, params = {}) {
   function openUrl(base) {
     const url = base + '?' + search.toString();
     try {
-      window.location.href = url;
+      window.top.location.assign(url);
     } catch (error) {
-      try {
-        window.top.location.href = url;
-      } catch (topError) {
-        window.open(url, '_blank');
-      }
+      window.location.assign(url);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the navigation helper updates location using `window.location.assign`
- update navigateTo functions across pages to avoid opening new tabs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a28ecf888323a26dd1b6656ffbaf