### PR TITLE
Fix blank page when returning via browser back

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -47,5 +47,12 @@
       window.location.assign(url);
     }
   }
+
+  // Reload the page when navigating back/forward to avoid blank screens
+  window.addEventListener('pageshow', function(evt) {
+    if (evt.persisted) {
+      window.location.reload();
+    }
+  });
 </script>
 // 617


### PR DESCRIPTION
## Summary
- fix a blank screen when navigating with the browser back button
- reload the page on `pageshow` if it comes from the bfcache

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5c0d2a48323ac37a927d5f0f0f7