### PR TITLE
Fix blank screen when navigating back

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -3993,7 +3993,9 @@ function createSignInPage() {
         
         // Handle back button to retry
         window.addEventListener('pageshow', function(event) {
-            if (event.persisted) {
+            var entries = performance.getEntriesByType('navigation');
+            var navType = entries.length > 0 ? entries[0].type : undefined;
+            if (event.persisted || navType === 'back_forward') {
                 location.reload();
             }
         });

--- a/_navigation.html
+++ b/_navigation.html
@@ -49,8 +49,11 @@
   }
 
   // Reload the page when navigating back/forward to avoid blank screens
+  // Some browsers do not set evt.persisted so also check the navigation type
   window.addEventListener('pageshow', function(evt) {
-    if (evt.persisted) {
+    var entries = performance.getEntriesByType('navigation');
+    var navType = entries.length > 0 ? entries[0].type : undefined;
+    if (evt.persisted || navType === 'back_forward') {
       window.location.reload();
     }
   });


### PR DESCRIPTION
## Summary
- improve back/forward detection when rendering navigation
- apply same fix to sign-in page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851ab2a4f2c832393de845808ceaf4f