### PR TITLE
Fix cross-browser back navigation

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -3993,8 +3993,19 @@ function createSignInPage() {
         
         // Handle back button to retry
         window.addEventListener('pageshow', function(event) {
-            var entries = performance.getEntriesByType('navigation');
-            var navType = entries.length > 0 ? entries[0].type : undefined;
+            var navType;
+            try {
+                if (performance.getEntriesByType) {
+                    var entries = performance.getEntriesByType('navigation');
+                    navType = entries.length > 0 ? entries[0].type : undefined;
+                } else if (performance.navigation) {
+                    if (performance.navigation.type === 2) navType = 'back_forward';
+                    else if (performance.navigation.type === 1) navType = 'reload';
+                    else navType = 'navigate';
+                }
+            } catch (e) {
+                navType = undefined;
+            }
             if (event.persisted || navType === 'back_forward') {
                 location.reload();
             }

--- a/_navigation.html
+++ b/_navigation.html
@@ -51,8 +51,19 @@
   // Reload the page when navigating back/forward to avoid blank screens
   // Some browsers do not set evt.persisted so also check the navigation type
   window.addEventListener('pageshow', function(evt) {
-    var entries = performance.getEntriesByType('navigation');
-    var navType = entries.length > 0 ? entries[0].type : undefined;
+    var navType;
+    try {
+      if (performance.getEntriesByType) {
+        var entries = performance.getEntriesByType('navigation');
+        navType = entries.length > 0 ? entries[0].type : undefined;
+      } else if (performance.navigation) {
+        if (performance.navigation.type === 2) navType = 'back_forward';
+        else if (performance.navigation.type === 1) navType = 'reload';
+        else navType = 'navigate';
+      }
+    } catch (e) {
+      navType = undefined;
+    }
     if (evt.persisted || navType === 'back_forward') {
       window.location.reload();
     }


### PR DESCRIPTION
## Summary
- update navigation component to robustly detect back navigation
- apply same logic in sign-in page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac1619348323bf79ea584e2621f8