### PR TITLE
Fix blank page when navigating back

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -4007,10 +4007,9 @@ function createSignInPage() {
                 navType = undefined;
             }
             if (event.persisted || navType === 'back_forward') {
-                location.reload();
+                location.replace(location.href);
             }
         });
-        window.addEventListener('unload', function() {});
     </script>
 </body>
 </html>`;

--- a/_navigation.html
+++ b/_navigation.html
@@ -65,10 +65,8 @@
       navType = undefined;
     }
     if (evt.persisted || navType === 'back_forward') {
-      window.location.reload();
+      window.location.replace(window.location.href);
     }
   });
-  // Prevent Safari back/forward cache from causing blank pages
-  window.addEventListener('unload', function() {});
 </script>
 // 617


### PR DESCRIPTION
## Summary
- replace reload with `location.replace` for back navigation
- drop unload handler to let browsers control caching

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851b03535888323a9d60149d985134c