### PR TITLE
Fix placeholder admin display and fallback role

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -326,10 +326,10 @@
         <h1>🏍️ Motorcycle Escort Management</h1>
         
         <div class="user-info">
-            <div class="user-avatar" id="userAvatar">A</div>
+            <div class="user-avatar" id="userAvatar">?</div>
             <div class="user-details">
-                <div class="user-name" id="userName">Administrator</div>
-                <div class="user-role" id="userRole">Admin</div>
+                <div class="user-name" id="userName">Loading...</div>
+                <div class="user-role" id="userRole">User</div>
             </div>
             <button class="logout-btn" onclick="logout()">Logout</button>
         </div>

--- a/index.html
+++ b/index.html
@@ -492,8 +492,8 @@
         const fallbackUser = (error && error.user) ? error.user : {
             name: 'System User',
             email: 'user@system.com',
-            roles: ['admin'],
-            permissions: ['view', 'create_request', 'assign_riders', 'send_notifications', 'view_reports']
+            roles: ['guest'],
+            permissions: []
         };
         handleUserDataSafely(fallbackUser);
         setFallbackValues();

--- a/user-management.html
+++ b/user-management.html
@@ -516,10 +516,10 @@
         <h1>🏍️ Motorcycle Escort Management</h1>
         
         <div class="user-info">
-            <div class="user-avatar" id="userAvatar">A</div>
+            <div class="user-avatar" id="userAvatar">?</div>
             <div class="user-details">
-                <div class="user-name" id="userName">Administrator</div>
-                <div class="user-role" id="userRole">Admin</div>
+                <div class="user-name" id="userName">Loading...</div>
+                <div class="user-role" id="userRole">User</div>
             </div>
             <button class="logout-btn" onclick="logout()">Logout</button>
         </div>


### PR DESCRIPTION
## Summary
- reduce privileges for fallback dashboard user
- remove hardcoded Administrator text from admin-dashboard and user-management pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68530416aa988323b0f216792aa657aa