### PR TITLE
Fix debug text on dashboard pages

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -824,4 +824,3 @@ function displaySystemLogs(logs) {
 </body>
 </html>
 
-// 617

--- a/admin-schedule.html
+++ b/admin-schedule.html
@@ -105,4 +105,3 @@
     </script>
 </body>
 </html>
-// 617


### PR DESCRIPTION
## Summary
- remove leftover debug text from `admin-dashboard` and `admin-schedule` pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853385ef3708323a383c08acb6879b1