### PR TITLE
Fix dashboard script tag display

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -6153,7 +6153,8 @@ function addMobileOptimizations(htmlOutput, user, rider) {
 })();
 </script>`;
     
-    htmlOutput.append(mobileScript);
+    // Use appendUntrusted so the script renders without escaping
+    htmlOutput.appendUntrusted(mobileScript);
     return htmlOutput;
     
   } catch (error) {


### PR DESCRIPTION
## Summary
- fix mobile script injection so `<script>` tags aren't rendered as plain text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68533b0bb3688323b59744a9e958da5f