### PR TITLE
Fix script injection placement in dashboard

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -1617,10 +1617,19 @@ window.currentUser = {
 };
 console.log('👤 User context loaded via addUserDataInjectionSafe (appended).');
 </script>`;
-    
-    htmlOutput.appendUntrusted(userScript); // Use appendUntrusted to inject raw HTML/JS
+
+    let content = htmlOutput.getContent();
+    if (content.includes('</body>')) {
+      content = content.replace('</body>', userScript + '\n</body>');
+    } else if (content.includes('</html>')) {
+      content = content.replace('</html>', userScript + '\n</html>');
+    } else {
+      content += userScript;
+    }
+
+    htmlOutput.setContent(content);
     // No return needed, or return htmlOutput if preferred by other parts of the system
-    
+
   } catch (error) {
     console.error('Error adding user data injection:', error);
     // Potentially return htmlOutput or throw, depending on error handling strategy

--- a/Code.gs
+++ b/Code.gs
@@ -5544,9 +5544,18 @@ window.UX = {
 
 console.log('✅ Enhanced UX package loaded');
 </script>`;
-    
-    // CORRECT METHOD: Use appendUntrusted instead of append
-    htmlOutput.appendUntrusted(userScript);
+
+    // Insert script before closing </body> or </html>
+    let content = htmlOutput.getContent();
+    if (content.includes('</body>')) {
+      content = content.replace('</body>', userScript + '\n</body>');
+    } else if (content.includes('</html>')) {
+      content = content.replace('</html>', userScript + '\n</html>');
+    } else {
+      content += userScript;
+    }
+
+    htmlOutput.setContent(content);
     return htmlOutput;
     
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure user data script injected before closing body tag
- fix same logic in fallback `addUserDataInjectionSafe`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854142321d48323a322b006f86dd82c