### PR TITLE
Fix sign-in reload loop

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -1430,10 +1430,10 @@ function createSignInPageEnhanced() {
         </div>
         
         <!-- Primary Sign-In Method -->
-        <button class="signin-btn" onclick="handleSignIn()">
+        <a href="${webAppUrl}" class="signin-btn">
             <div class="google-icon">G</div>
             Sign In with Google
-        </button>
+        </a>
         
         <!-- Debug Information -->
         <div class="debug-info">
@@ -1456,19 +1456,7 @@ function createSignInPageEnhanced() {
     
     <script>
         function handleSignIn() {
-            const btn = document.querySelector('.signin-btn');
-            btn.innerHTML = '<div class="google-icon">⏳</div>Signing In...';
-            btn.style.background = '#666';
-            
-            // Strategy 1: Direct reload to trigger auth
-            setTimeout(() => {
-                window.location.href = '${webAppUrl}?auth=true&t=' + Date.now();
-            }, 500);
-            
-            // Strategy 2: Fallback reload
-            setTimeout(() => {
-                window.location.reload();
-            }, 2000);
+            // OAuth prompt occurs automatically when visiting the web app.
         }
         
         function testUserSession() {


### PR DESCRIPTION
## Summary
- update sign in page to link directly to the web app root
- remove special reload logic that appended `?auth=true`
- replace `handleSignIn` with a no-op because Google handles auth automatically

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68548f96ffd08323a61686fd5b99d556