### PR TITLE
Add OAuth token helper

### DIFF
--- a/OAuthService.gs
+++ b/OAuthService.gs
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview
+ * OAuth utility functions for the Motorcycle Escort Management System.
+ */
+
+/**
+ * Returns an OAuth access token for the current script.
+ *
+ * Include this token in the `Authorization` header as a Bearer token
+ * when using `UrlFetchApp.fetch` to call Google APIs.
+ *
+ * Example:
+ * const headers = { 'Authorization': 'Bearer ' + getOAuthToken() };
+ * const response = UrlFetchApp.fetch('https://www.googleapis.com/drive/v3/files', {
+ *   'headers': headers
+ * });
+ *
+ * @return {string} OAuth token string.
+ */
+function getOAuthToken() {
+  return ScriptApp.getOAuthToken();
+}
+


### PR DESCRIPTION
## Summary
- provide an `OAuthService.gs` with a `getOAuthToken` helper
- document how to use this token with `UrlFetchApp` for Google API calls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68548fa329f483239f1d9c3515a17746