### PR TITLE
Fix role resolution for overlapping admin and dispatcher

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -706,20 +706,23 @@ function authenticateAndAuthorizeUser() {
     const rider = getRiderByGoogleEmailSafe(userSession.email);
     const adminUsers = getAdminUsersSafe();
     const dispatcherUsers = getDispatcherUsersSafe();
-    
+
     let userRole = 'unauthorized';
     let permissions = [];
-    
-    // Trace admin check
+
+    const isAdmin = adminUsers.includes(userSession.email);
+    const isDispatcher = dispatcherUsers.includes(userSession.email);
+
+    // Prefer dispatcher role if user appears in both lists
     console.log('🔍 Checking admin users:', adminUsers);
-    if (adminUsers.includes(userSession.email)) {
-      userRole = 'admin';
-      permissions = ['view_all', 'edit_all', 'assign_riders', 'manage_users', 'view_reports'];
-      traceAuthFunction('authenticateAndAuthorizeUser->role', userSession.email, 'admin');
-    } else if (dispatcherUsers.includes(userSession.email)) {
+    if (isDispatcher) {
       userRole = 'dispatcher';
       permissions = ['view_requests', 'create_requests', 'assign_riders', 'view_reports'];
       traceAuthFunction('authenticateAndAuthorizeUser->role', userSession.email, 'dispatcher');
+    } else if (isAdmin) {
+      userRole = 'admin';
+      permissions = ['view_all', 'edit_all', 'assign_riders', 'manage_users', 'view_reports'];
+      traceAuthFunction('authenticateAndAuthorizeUser->role', userSession.email, 'admin');
     } else if (rider && rider.status === 'Active') {
       userRole = 'rider';
       permissions = ['view_own_assignments', 'update_own_status'];


### PR DESCRIPTION
## Summary
- ensure dispatcher accounts aren't inadvertently granted admin privileges by giving dispatcher role priority when an email appears in both lists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854c1da6a008323a3382fdece277f5e