### PR TITLE
Fix unassigned filter to exclude assigned/completed

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -2373,8 +2373,12 @@ function getFilteredRequestsForWebApp(user, filter = 'All', rawRequestsInput = n
           continue;
         }
         
-        // Apply status filter
-        if (filter !== 'All' && status !== filter) {
+        // Apply status filter with special handling for "Unassigned"
+        if (filter === 'Unassigned') {
+          if (['Assigned', 'Completed', 'Cancelled'].includes(status)) {
+            continue; // Skip requests that are assigned or closed
+          }
+        } else if (filter !== 'All' && status !== filter) {
           continue;
         }
         


### PR DESCRIPTION
## Summary
- update server filtering logic so the **Unassigned** filter returns any request
  that isn't *Assigned*, *Completed* or *Cancelled*

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685592c7d19c83238e66e128a8e61735