### PR TITLE
Implement custom login with Google fallback

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -264,6 +264,23 @@ function getRoleBasedNavigation(currentPage, user, rider) {
 function getEnhancedUserSession() {
   try {
     console.log('🔍 getEnhancedUserSession called from AccessControl.gs');
+
+    // 0. Check for custom spreadsheet-based session
+    try {
+      const custom = getCustomSession();
+      if (custom) {
+        console.log('🔵 Custom session found for ' + custom.email);
+        return {
+          email: custom.email,
+          name: custom.name || '',
+          hasEmail: true,
+          hasName: !!custom.name,
+          source: 'custom_session'
+        };
+      }
+    } catch (e) {
+      console.log('⚠️ Custom session check failed: ' + e.message);
+    }
     
     let user = null;
     let userEmail = '';
@@ -1586,6 +1603,12 @@ function createSignInPageEnhanced() {
   
   return HtmlService.createHtmlOutput(html)
     .setTitle('Sign In - Escort Management')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function createHybridLoginPage() {
+  return HtmlService.createHtmlOutputFromFile('login')
+    .setTitle('Login - Escort Management')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
 

--- a/Code.gs
+++ b/Code.gs
@@ -3648,10 +3648,10 @@ function doGet(e) {
       // For other errors like NO_EMAIL, or if getEnhancedUserSession itself returned an error object
       if (authResult.error === 'NO_EMAIL' || (authResult.source === 'unidentified' && authResult.error)) {
          Logger.log(`User has no email or session is unidentified. Error: ${authResult.error}`);
-         return createSignInPageEnhanced(); // Or a more specific error page
+         return createHybridLoginPage();
       }
       // Default to sign-in for other unspecified errors
-      return createSignInPageEnhanced();
+      return createHybridLoginPage();
     }
     
     const { user: authenticatedUser, rider } = authResult;

--- a/HybridAuth.gs
+++ b/HybridAuth.gs
@@ -1,0 +1,82 @@
+function hashPassword(password) {
+  const raw = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, password);
+  return raw.map(b => ('0' + (b & 0xff).toString(16)).slice(-2)).join('');
+}
+
+function findUserRecord(email) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Users');
+  if (!sheet) return null;
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0].map(String);
+  const emailCol = headers.indexOf('email');
+  const passCol = headers.indexOf('hashedPassword');
+  const roleCol = headers.indexOf('role');
+  const statusCol = headers.indexOf('status');
+  const nameCol = headers.indexOf('name');
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    if (row[emailCol] === email) {
+      return {
+        email: row[emailCol],
+        hashedPassword: row[passCol],
+        role: row[roleCol],
+        status: row[statusCol],
+        name: row[nameCol]
+      };
+    }
+  }
+  return null;
+}
+
+const SESSION_DURATION_MS = 8 * 60 * 60 * 1000; // 8 hours
+
+function createCustomSession(user) {
+  const session = {
+    email: user.email,
+    name: user.name,
+    role: user.role,
+    expires: Date.now() + SESSION_DURATION_MS
+  };
+  PropertiesService.getUserProperties().setProperty('CUSTOM_SESSION', JSON.stringify(session));
+  return session;
+}
+
+function getCustomSession() {
+  const prop = PropertiesService.getUserProperties().getProperty('CUSTOM_SESSION');
+  if (!prop) return null;
+  try {
+    const sess = JSON.parse(prop);
+    if (sess.expires > Date.now()) {
+      return sess;
+    }
+  } catch (e) {}
+  PropertiesService.getUserProperties().deleteProperty('CUSTOM_SESSION');
+  return null;
+}
+
+function loginWithCredentials(email, password) {
+  const user = findUserRecord(email);
+  if (!user || user.status !== 'active') {
+    return { success: false, message: 'Invalid credentials' };
+  }
+  if (hashPassword(password) !== String(user.hashedPassword)) {
+    return { success: false, message: 'Invalid credentials' };
+  }
+  createCustomSession(user);
+  return { success: true, url: getWebAppUrlSafe() };
+}
+
+function loginWithGoogle() {
+  const auth = authenticateUser();
+  if (auth.success) {
+    createCustomSession(auth.user);
+    return { success: true, url: getWebAppUrlSafe() };
+  }
+  return auth;
+}
+
+function logoutUser() {
+  PropertiesService.getUserProperties().deleteProperty('CUSTOM_SESSION');
+  return { success: true };
+}

--- a/login.html
+++ b/login.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <style>
+    body {font-family: Arial, sans-serif;background:#f2f2f2;padding:2rem;}
+    #box {max-width:400px;margin:0 auto;background:#fff;border-radius:8px;padding:2rem;box-shadow:0 2px 6px rgba(0,0,0,0.2);}
+    input{width:100%;padding:8px;margin:6px 0;box-sizing:border-box;}
+    button{padding:10px 20px;margin-top:10px;cursor:pointer;}
+    #msg{color:red;margin-top:10px;}
+  </style>
+</head>
+<body>
+<div id="box">
+  <h2>Login</h2>
+  <input type="email" id="email" placeholder="Email">
+  <input type="password" id="password" placeholder="Password">
+  <button id="loginBtn">Log In</button>
+  <div style="text-align:center;margin:10px 0;">or</div>
+  <button id="googleBtn">Log in with Google</button>
+  <div id="msg"></div>
+</div>
+<script>
+  document.getElementById('loginBtn').addEventListener('click', function(){
+    const email=document.getElementById('email').value.trim();
+    const pw=document.getElementById('password').value;
+    google.script.run.withSuccessHandler(handle).loginWithCredentials(email,pw);
+  });
+  document.getElementById('googleBtn').addEventListener('click', function(){
+    google.script.run.withSuccessHandler(handle).loginWithGoogle();
+  });
+  function handle(res){
+    if(res && res.success){
+      window.location.href=res.url;
+    }else{
+      document.getElementById('msg').textContent=res.message||'Login failed';
+    }
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add spreadsheet-backed authentication helpers
- check for custom sessions in `getEnhancedUserSession`
- serve a hybrid login page when authentication fails
- add basic login HTML form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685593a9273883238f0ea25f498947e4