### PR TITLE
Fix: Remove hardcoded admins & enhance session logging

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -262,6 +262,41 @@ function getRoleBasedNavigation(currentPage, user, rider) {
  * This version prioritizes fresh session data over cached data
  */
 function getEnhancedUserSession() {
+  console.log('INVESTIGATION: getEnhancedUserSession invoked.');
+  try {
+    const rawActiveUser = Session.getActiveUser();
+    console.log('INVESTIGATION: Raw Session.getActiveUser() object:', rawActiveUser ? 'Exists' : 'Null');
+    if (rawActiveUser) {
+      // Attempt to get email and catch potential errors
+      try {
+        const activeUserEmail = rawActiveUser.getEmail();
+        console.log('INVESTIGATION: Raw Session.getActiveUser().getEmail() initial value:', activeUserEmail);
+        if (activeUserEmail === 'jpsotraffic@gmail.com') {
+          console.log("⚠️ INVESTIGATION: Session.getActiveUser().getEmail() IS 'jpsotraffic@gmail.com' at initial check.");
+        }
+      } catch (e) {
+        console.log('⚠️ INVESTIGATION: Error calling Session.getActiveUser().getEmail():', e.message);
+      }
+    }
+  } catch (e) {
+    console.log('⚠️ INVESTIGATION: Error accessing Session.getActiveUser():', e.message);
+  }
+
+  try {
+    const rawEffectiveUser = Session.getEffectiveUser();
+    console.log('INVESTIGATION: Raw Session.getEffectiveUser() object:', rawEffectiveUser ? 'Exists' : 'Null');
+    if (rawEffectiveUser) {
+      // Attempt to get email and catch potential errors
+      try {
+        console.log('INVESTIGATION: Raw Session.getEffectiveUser().getEmail() initial value:', rawEffectiveUser.getEmail());
+      } catch (e) {
+        console.log('⚠️ INVESTIGATION: Error calling Session.getEffectiveUser().getEmail():', e.message);
+      }
+    }
+  } catch (e) {
+    console.log('⚠️ INVESTIGATION: Error accessing Session.getEffectiveUser():', e.message);
+  }
+
   try {
     console.log('🔍 getEnhancedUserSession called from AccessControl.gs');
     
@@ -321,11 +356,17 @@ function getEnhancedUserSession() {
     // Method 3: Try PropertiesService for cached user info
     if (!userEmail) {
       try {
-        console.log('🔄 Trying cached user info...');
+        console.log('INVESTIGATION: Trying cached user info...'); // Modified existing log to INVESTIGATION
         const scriptProperties = PropertiesService.getScriptProperties();
         const cachedEmail = scriptProperties.getProperty('CACHED_USER_EMAIL');
         const cachedName = scriptProperties.getProperty('CACHED_USER_NAME');
-        console.log('🔵 Cached Email from PropertiesService:', cachedEmail);
+        console.log('INVESTIGATION: Cached email from PropertiesService:', cachedEmail);
+        console.log('INVESTIGATION: Cached name from PropertiesService:', cachedName);
+
+        if (cachedEmail === 'jpsotraffic@gmail.com') {
+          console.log("⚠️ INVESTIGATION: Cached email IS 'jpsotraffic@gmail.com'.");
+        }
+
         if (cachedEmail) {
           userEmail = cachedEmail;
           userName = cachedName || '';
@@ -1017,13 +1058,26 @@ function getAdminUsersFallback() {
 
     if (admins.length > 0) {
       console.log(`✅ Fallback: Loaded ${admins.length} admins from settings sheet:`, admins);
+      if (admins.includes('jpsotraffic@gmail.com')) {
+        console.log("⚠️ INVESTIGATION: 'jpsotraffic@gmail.com' IS present in the admin list returned by getAdminUsersFallback.");
+      } else {
+        console.log("ℹ️ INVESTIGATION: 'jpsotraffic@gmail.com' IS NOT present in the admin list returned by getAdminUsersFallback.");
+      }
       return admins;
     } else {
       console.log(`⚠️ Fallback: No admin emails found in range ${adminRangeA1} of sheet "${settingsSheetName}". Returning empty list.`);
+      // Even if the list is empty, perform the check (it will be false)
+      if (admins.includes('jpsotraffic@gmail.com')) { // This will be false
+        console.log("⚠️ INVESTIGATION: 'jpsotraffic@gmail.com' IS present in the admin list returned by getAdminUsersFallback (empty list scenario - unexpected).");
+      } else {
+        console.log("ℹ️ INVESTIGATION: 'jpsotraffic@gmail.com' IS NOT present in the admin list returned by getAdminUsersFallback (empty list scenario).");
+      }
       return [];
     }
   } catch (error) {
     console.log(`❌ Fallback: Could not read Settings sheet "${settingsSheetName}" for admin users. Error: ${error.message}. Returning empty list.`);
+    // Log for the error case before returning empty array
+    console.log("ℹ️ INVESTIGATION: 'jpsotraffic@gmail.com' IS NOT present in the admin list due to an error in getAdminUsersFallback.");
     return []; // Return empty array on error
   }
 }

--- a/Code.gs
+++ b/Code.gs
@@ -233,14 +233,9 @@ function getAdminUsers() {
     console.log('❌ Error accessing spreadsheet:', error.message);
   }
   
-  // Fallback to hardcoded admin emails
-  console.log('📧 Using hardcoded admin fallback');
-  return [
-    'admin@yourdomain.com',
-    'jpsotraffic@gmail.com',
-    'manager@yourdomain.com'
-    // Add your admin emails here
-  ];
+  // Fallback removed
+  console.log('INFO in getAdminUsers (Code.gs - simple version): Failed to retrieve admins from Settings sheet or no admins found. Returning empty list.');
+  return [];
 }
 /**
  * Fix the Settings sheet structure to have clean email data
@@ -323,17 +318,17 @@ function fixSettingsSheetStructure() {
  * Robust admin email reading function that handles mixed data types
  * REPLACE your getAdminUsers function with this version
  */
-function getAdminUsers() {
+function getAdminUsers() { // This is the second (robust) definition
   console.log('🔍 getAdminUsers called (robust version)...');
   
   try {
     const settingsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Settings');
     if (settingsSheet) {
-      console.log('📖 Reading admin emails from Settings sheet...');
+      console.log('📖 Reading admin emails from Settings sheet (robust version)...');
       
       // Read the range
       const adminRange = settingsSheet.getRange('B2:B11').getValues(); // Extended range
-      console.log('📊 Raw admin range data:', adminRange);
+      // console.log('📊 Raw admin range data (robust):', adminRange); // Keep original log for verbosity if needed, or remove for cleaner prod logs
       
       // Robust filtering to handle mixed data types
       const adminEmails = adminRange
@@ -358,27 +353,31 @@ function getAdminUsers() {
         })
         .map(email => email.trim()); // Clean up the emails
       
-      console.log('📧 Filtered admin emails:', adminEmails);
+      // console.log('📧 Filtered admin emails (robust):', adminEmails); // Keep original log for verbosity if needed
       
       if (adminEmails.length > 0) {
+        console.log('✅ INFO in getAdminUsers (Code.gs - robust version): Successfully retrieved ' + adminEmails.length + ' admin(s) from Settings sheet.');
         return adminEmails;
       } else {
-        console.log('⚠️ No valid admin emails found in Settings sheet');
+        console.log('INFO in getAdminUsers (Code.gs - robust version): No valid admin emails found in Settings sheet. Returning empty list.');
+        return [];
       }
     } else {
-      console.log('⚠️ Settings sheet not found');
+      console.log('INFO in getAdminUsers (Code.gs - robust version): Settings sheet not found. Returning empty list.');
+      return [];
     }
-  } catch (error) {
-    console.log('❌ Error reading Settings sheet:', error.message);
+  } catch (e) { // Changed error variable to 'e' to match logging style
+    console.log('ERROR in getAdminUsers (Code.gs - robust version): Failed to retrieve admins from Settings sheet. Returning empty list. Error: ' + e.message);
+    return [];
   }
   
-  // Fallback to hardcoded admin emails
-  console.log('📧 Using hardcoded admin fallback');
-  return [
-    'dashort@gmail.com',
-    'jpsotraffic@gmail.com',
-    'manager@example.com'
-  ];
+  // Fallback removed - The above logic should return [] if sheet/data is not found or on error.
+  // console.log('📧 Using hardcoded admin fallback');
+  // return [
+  //   'dashort@gmail.com',
+  //   'jpsotraffic@gmail.com',
+  //   'manager@example.com'
+  // ];
 }
 
 /**
@@ -3633,6 +3632,38 @@ function debugNotificationsFile() {
 
 
 function doGet(e) {
+  // Inside doGet(e) in Code.gs, at the very beginning
+  console.log('INVESTIGATION: doGet (Code.gs) invoked.');
+  try {
+    const activeUser = Session.getActiveUser();
+    if (activeUser) {
+      const activeUserEmail = activeUser.getEmail();
+      console.log('INVESTIGATION: doGet (Code.gs) - Session.getActiveUser().getEmail():', activeUserEmail);
+      if (activeUserEmail === 'jpsotraffic@gmail.com') {
+        console.log("⚠️ INVESTIGATION: doGet (Code.gs) - Session.getActiveUser().getEmail() IS 'jpsotraffic@gmail.com'.");
+      }
+    } else {
+      console.log('INVESTIGATION: doGet (Code.gs) - Session.getActiveUser() is null.');
+    }
+  } catch (e) {
+    console.log('⚠️ INVESTIGATION: doGet (Code.gs) - Error calling Session.getActiveUser().getEmail():', e.message);
+  }
+
+  try {
+    const effectiveUser = Session.getEffectiveUser();
+    if (effectiveUser) {
+      const effectiveUserEmail = effectiveUser.getEmail();
+      console.log('INVESTIGATION: doGet (Code.gs) - Session.getEffectiveUser().getEmail():', effectiveUserEmail);
+      if (effectiveUserEmail === 'jpsotraffic@gmail.com') {
+        console.log("⚠️ INVESTIGATION: doGet (Code.gs) - Session.getEffectiveUser().getEmail() IS 'jpsotraffic@gmail.com'.");
+      }
+    } else {
+      console.log('INVESTIGATION: doGet (Code.gs) - Session.getEffectiveUser() is null.');
+    }
+  } catch (e) {
+    console.log('⚠️ INVESTIGATION: doGet (Code.gs) - Error calling Session.getEffectiveUser().getEmail():', e.message);
+  }
+
   try {
     console.log('🚀 doGet with cache-friendly headers...');
     


### PR DESCRIPTION
This commit addresses the persistent issue of 'jpsotraffic@gmail.com' potentially gaining admin access or being misidentified as the logged-in user.

Key changes:
- Critical Fix: Modified `getAdminUsers()` functions in `Code.gs` to remove hardcoded fallback admin lists that included 'jpsotraffic@gmail.com'. These functions now correctly return an empty array if admins cannot be retrieved from the Settings sheet, preventing 'jpsotraffic@gmail.com' from becoming an admin via this vector.
- Enhanced Logging in `getEnhancedUserSession` (AccessControl.gs):
    - Added detailed logging to trace the source of the user's email (Session.getActiveUser, Session.getEffectiveUser, PropertiesService cache).
    - Specific log entries will highlight if 'jpsotraffic@gmail.com' is returned by any of these sources.
    - Logs initial raw session states.
- Enhanced Logging in `doGet` (Code.gs):
    - Added logging at the very beginning of `doGet` to capture the emails from `Session.getActiveUser()` and `Session.getEffectiveUser()` as soon as a request is received.
- Logging for Admin List Contents:
    - Added logging in `getAdminUsersFallback` (AccessControl.gs) to indicate if 'jpsotraffic@gmail.com' is part of the admin list it returns (though this function is less likely to be the primary source of admins now).

The primary goal of these changes is to make the application rely strictly on the Settings sheet for admin definitions and to provide comprehensive logging to diagnose any remaining session or user identification anomalies, particularly concerning 'jpsotraffic@gmail.com'.