### PR TITLE
Fix missing navigation on dashboard

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -338,7 +338,7 @@
         </div>
     </div>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <!-- Admin Header -->
@@ -659,5 +659,6 @@ Session: Active
 
         console.log('✅ Admin dashboard script loaded successfully');
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/admin-schedule.html
+++ b/admin-schedule.html
@@ -38,7 +38,7 @@
         <h1>🏍️ Motorcycle Escort Management</h1>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <h2>🗓️ Manage Rider Availability</h2>
@@ -103,5 +103,6 @@
         document.getElementById('riderEmail').addEventListener('change', loadAvailability);
         document.addEventListener('DOMContentLoaded', loadRiders);
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/assignments.html
+++ b/assignments.html
@@ -525,7 +525,7 @@
         </div>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <div class="assignments-layout">
@@ -1930,5 +1930,6 @@ function updateAssignmentOrder() {
     }
 
 </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
     </header>
 
     <div class="container">
-        <!--NAVIGATION_MENU_PLACEHOLDER-->
+        <div id="navigation-container"></div>
 
         <div class="dashboard-grid">
             <!-- Statistics Card -->
@@ -895,5 +895,6 @@
     // Debug helper (disabled)
     // debugNavigation();
 </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/load-navigation.js
+++ b/load-navigation.js
@@ -1,0 +1,28 @@
+// Dynamically load the navigation menu for local testing
+function injectNavigation() {
+  const placeholder = document.getElementById('navigation-container');
+  if (!placeholder) return;
+  fetch('_navigation.html')
+    .then(res => res.text())
+    .then(html => {
+      placeholder.innerHTML = html;
+      // Execute any scripts from the loaded HTML
+      placeholder.querySelectorAll('script').forEach(old => {
+        const script = document.createElement('script');
+        if (old.src) {
+          script.src = old.src;
+        } else {
+          script.textContent = old.textContent;
+        }
+        document.head.appendChild(script);
+        old.remove();
+      });
+    })
+    .catch(err => console.error('Failed to load navigation', err));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', injectNavigation);
+} else {
+  injectNavigation();
+}

--- a/mobile-requests.html
+++ b/mobile-requests.html
@@ -340,7 +340,7 @@
         <h1>🏍️ Escort Requests</h1>
     </div>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
     
     <div class="mobile-controls">
         <div class="filter-section">
@@ -756,5 +756,6 @@
             vibrate([5]);
         });
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/notifications.html
+++ b/notifications.html
@@ -515,7 +515,7 @@
             <button class="logout-btn" onclick="logout()">Logout</button>
         </div>
     </header>
-     <!--NAVIGATION_MENU_PLACEHOLDER-->
+     <div id="navigation-container"></div>
 
     <div class="container">
         
@@ -1619,5 +1619,6 @@ ${result.message || 'Completed'}`;
             }
         }
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/reports.html
+++ b/reports.html
@@ -370,7 +370,7 @@
         </div>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <div class="reports-header">
@@ -825,6 +825,7 @@ function displayRiderActivityReport(result) {
                 '<style>body{font-family:Arial,sans-serif;padding:1rem;}table{border-collapse:collapse;width:100%;}' +
                 'th,td{border:1px solid #ccc;padding:.5rem;text-align:left;}th{background:#f4f4f4;}</style>' +
                 '</head><body><h2>Rider Activity Report</h2><table><thead><tr><th>Rider</th><th>Escorts</th>' +
+<script src="load-navigation.js"></script>
                 '<th>Total Hours</th></tr></thead><tbody>' + rows + '</tbody></table></body></html>';
 
             var reportWindow = window.open('', '_blank');
@@ -859,6 +860,7 @@ function displayRiderActivityReport(result) {
                 '<p>Total Hours: ' + escapeHtml(result.data.totalHours) + '</p>' +
                 '<h3>Request Type Distribution</h3>' +
                 '<table><thead><tr><th>Type</th><th>Count</th></tr></thead><tbody>' + rows + '</tbody></table>' +
+<script src="load-navigation.js"></script>
                 '</body></html>';
 
             var reportWindow = window.open('', '_blank');
@@ -915,5 +917,6 @@ function displayRiderActivityReport(result) {
             }
         }
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/requests.html
+++ b/requests.html
@@ -433,7 +433,7 @@
         <h1>🏍️ Escort Requests</h1>
     </header>
 
-<!--NAVIGATION_MENU_PLACEHOLDER-->
+<div id="navigation-container"></div>
 
         <div class="filter-row">
             <label><strong>Filter:</strong></label>
@@ -1398,5 +1398,6 @@ function navigateTo(page, params = {}) {
         }
     }
 </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/rider-assignments.html
+++ b/rider-assignments.html
@@ -42,7 +42,7 @@
         <h1>🏍️ Motorcycle Escort Management</h1>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <h2>🏍️ My Escorts</h2>
@@ -79,5 +79,6 @@
 
         document.addEventListener('DOMContentLoaded', loadAssignments);
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/rider-schedule.html
+++ b/rider-schedule.html
@@ -48,7 +48,7 @@
         <h1>🏍️ Motorcycle Escort Management</h1>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <h2>📆 My Availability</h2>
@@ -131,5 +131,6 @@
             loadAvailability();
         });
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/riders.html
+++ b/riders.html
@@ -491,7 +491,7 @@
         </div>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <div class="riders-header">
@@ -2118,5 +2118,6 @@ function logout() {
   }
 }
 </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>

--- a/user-management.html
+++ b/user-management.html
@@ -525,7 +525,7 @@
         </div>
     </header>
 
-    <!--NAVIGATION_MENU_PLACEHOLDER-->
+    <div id="navigation-container"></div>
 
     <div class="container">
         <!-- Page Header -->
@@ -1200,5 +1200,6 @@
             }
         }
     </script>
+<script src="load-navigation.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load a shared navigation bar into HTML pages for local testing
- fetch `_navigation.html` at runtime via `load-navigation.js`
- hook up the loader script across all main pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68571b4a044c832384a76c5c193fd1a6