### PR TITLE
Fix broken navigation links

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -31,33 +31,11 @@
         });
     }
 
-    // Navigation click handler
-    function handleNavigation(link) {
-        var url = link.dataset.url || link.getAttribute('href');
-        if (!url || url === '#') return false;
-        
-        try {
-            if (window.top !== window) {
-                window.top.location.href = url;
-            } else {
-                window.location.href = url;
-            }
-        } catch (e) {
-            window.location.href = url;
-        }
-        return false;
-    }
-
-    // Add click handlers to navigation links
+    // Navigation links rely on standard browser behavior. This avoids issues
+    // where custom click handlers prevent navigation when base URLs are not
+    // correctly resolved.
     document.addEventListener('DOMContentLoaded', function() {
-        document.querySelectorAll('nav.navigation a').forEach(function(link) {
-            link.addEventListener('click', function(e) {
-                e.preventDefault();
-                handleNavigation(this);
-            });
-        });
-        
-        console.log('🧭 Navigation initialized - NO AUTO RELOAD');
+        console.log('🧭 Navigation initialized');
     });
 
     // CRITICAL: NO PAGESHOW RELOAD - Let browser handle back/forward naturally


### PR DESCRIPTION
## Summary
- remove custom click handler from navigation
- rely on normal anchor behavior to navigate between pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685723708a888323a958c70260d1e9ec