### PR TITLE
Fix navigation fallback links

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -11,6 +11,17 @@
 (function() {
     // Set up navigation links
     function setLinks(base) {
+        if (!base || base === '#') {
+            // Fallback if the web app URL couldn't be retrieved
+            document.querySelectorAll('nav.navigation a').forEach(function(a) {
+                var page = a.getAttribute('data-page');
+                var href = page === 'dashboard' ? 'index.html' : page + '.html';
+                a.href = href;
+                a.dataset.url = href;
+            });
+            return;
+        }
+
         document.querySelectorAll('nav.navigation a').forEach(function(a) {
             var page = a.getAttribute('data-page');
             var href = page === 'dashboard' ? base : base + '?page=' + page;


### PR DESCRIPTION
## Summary
- handle missing webapp URL when generating navigation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68572a0b0bf48323b331b3fcfb1b2a2e