### PR TITLE
Fix dashboard navigation rendering

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -16,5 +16,18 @@ function navigateToPage(url) {
 }
 
 // It's good practice to indicate when scripts are loaded, especially for debugging.
-console.log('📄 _navigation.html script loaded - navigateToPage() is available.');
+// If running inside the Apps Script web app, adjust links to use ?page= parameters
+(function() {
+    const isAppsScript = typeof google !== 'undefined' && google.script && google.script.run;
+    if (isAppsScript) {
+        document.querySelectorAll('nav.navigation a[data-page]').forEach(a => {
+            const page = a.getAttribute('data-page');
+            const url = page === 'dashboard' ? '?page=dashboard' : `?page=${page}`;
+            a.setAttribute('href', url);
+            a.removeAttribute('target');
+        });
+    }
+    console.log('📄 _navigation.html script loaded - links adjusted:', isAppsScript);
+})();
+</script>
 </script>

--- a/index.html
+++ b/index.html
@@ -897,6 +897,6 @@
     // Debug helper (disabled)
     // debugNavigation();
 </script>
-<!-- <script src="load-navigation.js"></script> -->
+<script src="load-navigation.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure navigation links work in Apps Script by converting to `?page=` URLs when needed
- include navigation loader script in dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685814bb6ef883238243e43f7ccb40d3