### PR TITLE
Update dashboard stats

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -514,18 +514,30 @@ function getAdminDashboardData() {
       console.log('⚠️ Error calculating today requests:', e.message);
     }
     
-    // Calculate active escorts
-    let activeEscorts = 0;
+    // Calculate unassigned escorts within the next 3 days
+    let unassignedEscorts = 0;
     try {
-      activeEscorts = assignments.filter(a => 
-        a.status === 'In Progress' || a.status === 'Active' || a.status === 'Pending'
-      ).length;
+      const now = new Date();
+      const threeDays = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 3);
+      unassignedEscorts = assignments.filter(a => {
+        const eventDate = new Date(a.eventDate || a['Event Date']);
+        return eventDate && eventDate >= now && eventDate <= threeDays &&
+          a.status !== 'Assigned';
+      }).length;
     } catch (e) {
-      console.log('⚠️ Error calculating active escorts:', e.message);
+      console.log('⚠️ Error calculating unassigned escorts:', e.message);
     }
-    
+
     // Calculate active riders
     const activeRiders = riders.filter(r => r.status === 'Active').length;
+
+    // Calculate pending assignments
+    let pendingAssignments = 0;
+    try {
+      pendingAssignments = assignments.filter(a => a.status === 'Pending').length;
+    } catch (e) {
+      console.log('⚠️ Error calculating pending assignments:', e.message);
+    }
     
     const result = {
       totalRequests: requests.length,
@@ -533,9 +545,8 @@ function getAdminDashboardData() {
       totalAssignments: assignments.length,
       systemUsers: riders.length + admins.length + dispatchers.length,
       todayRequests: todayRequests,
-      activeEscorts: activeEscorts,
-      onlineRiders: activeRiders, // Simplified for now
-      systemHealth: 98
+      unassignedEscorts: unassignedEscorts,
+      pendingAssignments: pendingAssignments
     };
     
     console.log('✅ Admin dashboard data:', result);
@@ -551,9 +562,8 @@ function getAdminDashboardData() {
       totalAssignments: 0,
       systemUsers: 0,
       todayRequests: 0,
-      activeEscorts: 0,
-      onlineRiders: 0,
-      systemHealth: 100
+      unassignedEscorts: 0,
+      pendingAssignments: 0
     };
   }
 }

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -351,16 +351,12 @@
                 <div class="quick-stat-label">Today's Requests</div>
             </div>
             <div class="quick-stat">
-                <div class="quick-stat-number" id="activeEscorts">-</div>
-                <div class="quick-stat-label">Active Escorts</div>
+                <div class="quick-stat-number" id="unassignedEscorts">-</div>
+                <div class="quick-stat-label">Unassigned Escorts (3&nbsp;day)</div>
             </div>
             <div class="quick-stat">
-                <div class="quick-stat-number" id="onlineRiders">-</div>
-                <div class="quick-stat-label">Online Riders</div>
-            </div>
-            <div class="quick-stat">
-                <div class="quick-stat-number" id="systemHealth">100%</div>
-                <div class="quick-stat-label">System Health</div>
+                <div class="quick-stat-number" id="pendingAssignments">-</div>
+                <div class="quick-stat-label">Pending Assignments</div>
             </div>
         </div>
 
@@ -521,9 +517,8 @@
 
                 // Update quick stats
                 document.getElementById('todayRequests').textContent = data.todayRequests || 0;
-                document.getElementById('activeEscorts').textContent = data.activeEscorts || 0;
-                document.getElementById('onlineRiders').textContent = data.onlineRiders || 0;
-                document.getElementById('systemHealth').textContent = (data.systemHealth || 100) + '%';
+                document.getElementById('unassignedEscorts').textContent = data.unassignedEscorts || 0;
+                document.getElementById('pendingAssignments').textContent = data.pendingAssignments || 0;
 
                 console.log('✅ Dashboard stats updated');
             } catch (error) {
@@ -789,9 +784,8 @@ function displaySystemLogs(logs) {
                 totalAssignments: 89,
                 systemUsers: 45,
                 todayRequests: 12,
-                activeEscorts: 3,
-                onlineRiders: 8,
-                systemHealth: 97
+                unassignedEscorts: 2,
+                pendingAssignments: 5
             };
         }
 


### PR DESCRIPTION
## Summary
- tweak quick stats on admin dashboard
- remove online rider/system health stats
- show unassigned escorts within three days and pending assignments
- update admin dashboard data function to compute new stats

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68581c29f3588323a78e37dbd62b8d27