### PR TITLE
Implement hybrid login

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -7950,6 +7950,9 @@ function getRoleBasedNavigationSafe(currentPage, user, rider) {
  */
 function logout() {
   try {
+    if (typeof logoutUser === 'function') {
+      logoutUser();
+    }
     PropertiesService.getScriptProperties().deleteProperty('CACHED_USER_EMAIL');
     PropertiesService.getScriptProperties().deleteProperty('CACHED_USER_NAME');
   } catch (error) {


### PR DESCRIPTION
## Summary
- check for custom login session before using Google auth
- support role-based permissions for custom session
- add login page handler to `doGet`
- provide a simple login page creator
- clear custom session during logout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858262ae5f48323b90d180659024cc5