### PR TITLE
Update dashboard escort stats

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -550,6 +550,19 @@ function getAdminDashboardData() {
       console.log('⚠️ Error calculating unassigned escorts:', e.message);
     }
 
+    // Calculate escorts within the next 3 days
+    let threeDayEscorts = 0;
+    try {
+      const now = new Date();
+      const threeDays = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 3);
+      threeDayEscorts = assignments.filter(a => {
+        const eventDate = new Date(a.eventDate || a['Event Date']);
+        return eventDate && eventDate >= now && eventDate <= threeDays;
+      }).length;
+    } catch (e) {
+      console.log('⚠️ Error calculating 3 day escorts:', e.message);
+    }
+
     // Calculate active riders
     const activeRiders = riders.filter(r => r.status === 'Active').length;
 
@@ -568,7 +581,8 @@ function getAdminDashboardData() {
       systemUsers: riders.length + admins.length + dispatchers.length,
       todayRequests: todayRequests,
       unassignedEscorts: unassignedEscorts,
-      pendingAssignments: pendingAssignments
+      pendingAssignments: pendingAssignments,
+      threeDayEscorts: threeDayEscorts
     };
     
     console.log('✅ Admin dashboard data:', result);
@@ -585,7 +599,8 @@ function getAdminDashboardData() {
       systemUsers: 0,
       todayRequests: 0,
       unassignedEscorts: 0,
-      pendingAssignments: 0
+      pendingAssignments: 0,
+      threeDayEscorts: 0
     };
   }
 }

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -348,15 +348,15 @@
         <div class="quick-stats">
             <div class="quick-stat">
                 <div class="quick-stat-number" id="todayRequests">-</div>
-                <div class="quick-stat-label">Today's Requests</div>
+                <div class="quick-stat-label">Today's Escorts</div>
+            </div>
+            <div class="quick-stat">
+                <div class="quick-stat-number" id="threeDayEscorts">-</div>
+                <div class="quick-stat-label">3 Day Escorts</div>
             </div>
             <div class="quick-stat">
                 <div class="quick-stat-number" id="unassignedEscorts">-</div>
                 <div class="quick-stat-label">Unassigned Escorts (3&nbsp;day)</div>
-            </div>
-            <div class="quick-stat">
-                <div class="quick-stat-number" id="pendingAssignments">-</div>
-                <div class="quick-stat-label">Pending Assignments</div>
             </div>
         </div>
 
@@ -517,8 +517,8 @@
 
                 // Update quick stats
                 document.getElementById('todayRequests').textContent = data.todayRequests || 0;
+                document.getElementById('threeDayEscorts').textContent = data.threeDayEscorts || 0;
                 document.getElementById('unassignedEscorts').textContent = data.unassignedEscorts || 0;
-                document.getElementById('pendingAssignments').textContent = data.pendingAssignments || 0;
 
                 console.log('✅ Dashboard stats updated');
             } catch (error) {
@@ -784,8 +784,8 @@ function displaySystemLogs(logs) {
                 totalAssignments: 89,
                 systemUsers: 45,
                 todayRequests: 12,
-                unassignedEscorts: 2,
-                pendingAssignments: 5
+                threeDayEscorts: 5,
+                unassignedEscorts: 2
             };
         }
 


### PR DESCRIPTION
## Summary
- rename today's requests to today's escorts
- show 3 day escorts and reorder quick stats
- surface three day escort count from `getAdminDashboardData`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858286610688323942dffb3c8504db4