### PR TITLE
Update dashboard with pending notifications

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -560,12 +560,21 @@ function getAdminDashboardData() {
     } catch (e) {
       console.log('⚠️ Error calculating pending assignments:', e.message);
     }
+
+    // Calculate notifications pending (assigned riders not yet notified)
+    let pendingNotifications = 0;
+    try {
+      const toNotify = getAssignmentsNeedingNotification();
+      pendingNotifications = Array.isArray(toNotify) ? toNotify.length : 0;
+    } catch (e) {
+      console.log('⚠️ Error calculating pending notifications:', e.message);
+    }
     
     const result = {
       totalRequests: requests.length,
       totalRiders: activeRiders,
       totalAssignments: assignments.length,
-      systemUsers: riders.length + admins.length + dispatchers.length,
+      pendingNotifications: pendingNotifications,
       todayRequests: todayRequests,
       unassignedEscorts: unassignedEscorts,
       pendingAssignments: pendingAssignments
@@ -582,7 +591,7 @@ function getAdminDashboardData() {
       totalRequests: 0,
       totalRiders: 0,
       totalAssignments: 0,
-      systemUsers: 0,
+      pendingNotifications: 0,
       todayRequests: 0,
       unassignedEscorts: 0,
       pendingAssignments: 0

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -374,9 +374,9 @@
                 <div class="stat-number" id="totalAssignments">-</div>
                 <div class="stat-label">Assignments</div>
             </div>
-            <div class="stat-card system" style="cursor:pointer" onclick="navigateStat('user-management')">
-                <div class="stat-number" id="systemUsers">-</div>
-                <div class="stat-label">System Users</div>
+            <div class="stat-card system" style="cursor:pointer" onclick="navigateStat('notifications')">
+                <div class="stat-number" id="pendingNotifications">-</div>
+                <div class="stat-label">Notifications</div>
             </div>
         </div>
 
@@ -513,7 +513,7 @@
                 document.getElementById('totalRequests').textContent = data.totalRequests || 0;
                 document.getElementById('totalRiders').textContent = data.totalRiders || 0;
                 document.getElementById('totalAssignments').textContent = data.totalAssignments || 0;
-                document.getElementById('systemUsers').textContent = data.systemUsers || 0;
+                document.getElementById('pendingNotifications').textContent = data.pendingNotifications || 0;
 
                 // Update quick stats
                 document.getElementById('todayRequests').textContent = data.todayRequests || 0;
@@ -782,7 +782,7 @@ function displaySystemLogs(logs) {
                 totalRequests: 156,
                 totalRiders: 23,
                 totalAssignments: 89,
-                systemUsers: 45,
+                pendingNotifications: 3,
                 todayRequests: 12,
                 unassignedEscorts: 2,
                 pendingAssignments: 5


### PR DESCRIPTION
## Summary
- show pending notifications on admin dashboard instead of system users
- link stat card to the notifications page
- compute pending notifications count in backend data service

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68582896c76c83238b62e82fd415644b