### PR TITLE
Fix today's escorts count

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -524,6 +524,7 @@ function getAdminDashboardData() {
     
     // Calculate today's requests
     let todayRequests = 0;
+    let todaysEscorts = 0; // Number of assignments scheduled for today
     try {
       todayRequests = requests.filter(r => {
         const reqDate = r.dateCreated || r['Date Created'] || r.date || '';
@@ -534,6 +535,16 @@ function getAdminDashboardData() {
       }).length;
     } catch (e) {
       console.log('⚠️ Error calculating today requests:', e.message);
+    }
+
+    // Calculate escorts scheduled for today
+    try {
+      todaysEscorts = assignments.filter(a => {
+        const eventDate = a.eventDate || a['Event Date'];
+        return eventDate && new Date(eventDate).toDateString() === todayStr;
+      }).length;
+    } catch (e) {
+      console.log('⚠️ Error calculating todays escorts:', e.message);
     }
     
     // Calculate unassigned escorts within the next 3 days
@@ -589,6 +600,7 @@ function getAdminDashboardData() {
       totalAssignments: assignments.length,
       pendingNotifications: pendingNotifications,
       todayRequests: todayRequests,
+      todaysEscorts: todaysEscorts,
       unassignedEscorts: unassignedEscorts,
       pendingAssignments: pendingAssignments,
       threeDayEscorts: threeDayEscorts
@@ -607,6 +619,7 @@ function getAdminDashboardData() {
       totalAssignments: 0,
       pendingNotifications: 0,
       todayRequests: 0,
+      todaysEscorts: 0,
       unassignedEscorts: 0,
       pendingAssignments: 0,
       threeDayEscorts: 0

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -347,7 +347,7 @@
         <!-- Quick Stats -->
         <div class="quick-stats">
             <div class="quick-stat">
-                <div class="quick-stat-number" id="todayRequests">-</div>
+                <div class="quick-stat-number" id="todaysEscorts">-</div>
                 <div class="quick-stat-label">Today's Escorts</div>
             </div>
             <div class="quick-stat">
@@ -516,7 +516,7 @@
                 document.getElementById('pendingNotifications').textContent = data.pendingNotifications || 0;
 
                 // Update quick stats
-                document.getElementById('todayRequests').textContent = data.todayRequests || 0;
+                document.getElementById('todaysEscorts').textContent = data.todaysEscorts || 0;
                 document.getElementById('threeDayEscorts').textContent = data.threeDayEscorts || 0;
                 document.getElementById('unassignedEscorts').textContent = data.unassignedEscorts || 0;
 
@@ -783,7 +783,7 @@ function displaySystemLogs(logs) {
                 totalRiders: 23,
                 totalAssignments: 89,
                 pendingNotifications: 3,
-                todayRequests: 12,
+                todaysEscorts: 12,
                 threeDayEscorts: 5,
                 unassignedEscorts: 2
             };


### PR DESCRIPTION
## Summary
- compute today's escorts from assignments
- update dashboard to show todaysEscorts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859c50415ac832386c2c80ceef97931