### PR TITLE
Add email response viewer

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -4238,6 +4238,31 @@ function getSystemLogs(limit) {
 }
 
 /**
+ * Returns recent rider email responses.
+ * @param {number} [limit=50] Maximum number of responses to return.
+ * @return {Array<Object>} Array of response objects.
+ */
+function getEmailResponses(limit) {
+  try {
+    var max = limit || 50;
+    var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Email_Responses');
+    if (!sheet) return [];
+    var data = sheet.getDataRange().getValues();
+    if (data.length <= 1) return [];
+    var headers = data[0];
+    var rows = data.slice(-Math.min(max, data.length - 1)).reverse();
+    return rows.map(function(row) {
+      var entry = {};
+      headers.forEach(function(h, i) { entry[h] = row[i]; });
+      return entry;
+    });
+  } catch (error) {
+    logError('Error in getEmailResponses', error);
+    return [];
+  }
+}
+
+/**
  * Retrieves the current assignment rotation order from script properties.
  * Generates a default order from active riders if none exists.
  * @return {string[]} Ordered list of rider names.

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -433,6 +433,9 @@
                     <button class="btn btn-primary" onclick="generateReports()">
                         📊 Generate Reports
                     </button>
+                    <button class="btn btn-primary" onclick="viewEmailResponses()">
+                        📧 Email Responses
+                    </button>
                 </div>
             </div>
 
@@ -643,6 +646,41 @@ function displaySystemLogs(logs) {
                      '<td>' + (log.Type || log.type || '') + '</td>' +
                      '<td>' + (log.Message || log.message || '') + '</td>' +
                      '<td>' + (log.Details || log.details || '') + '</td></tr>');
+        });
+        doc.write('</table>');
+    }
+    doc.write('</body></html>');
+    doc.close();
+}
+
+        function viewEmailResponses() {
+            if (typeof google !== 'undefined' && google.script && google.script.run) {
+                google.script.run
+                    .withSuccessHandler(function(responses) {
+                        displayEmailResponses(responses);
+                    })
+                    .withFailureHandler(handleError)
+                    .getEmailResponses();
+            } else {
+                alert('Email responses feature requires Google Apps Script connection');
+            }
+        }
+function displayEmailResponses(responses) {
+    const win = window.open('', '_blank', 'width=900,height=600,scrollbars=yes');
+    const doc = win.document;
+    doc.write('<html><head><title>Rider Email Responses</title></head><body>');
+    doc.write('<h2>Rider Email Responses</h2>');
+    if (!responses || responses.length === 0) {
+        doc.write('<p>No responses available.</p>');
+    } else {
+        doc.write('<table border="1" style="border-collapse: collapse; width: 100%;">');
+        doc.write('<tr><th>Timestamp</th><th>From Email</th><th>Rider Name</th><th>Message Body</th><th>Action</th></tr>');
+        responses.forEach(function(r) {
+            doc.write('<tr><td>' + (r.Timestamp || r.timestamp || '') + '</td>' +
+                     '<td>' + (r["From Email"] || r.fromEmail || '') + '</td>' +
+                     '<td>' + (r["Rider Name"] || r.riderName || '') + '</td>' +
+                     '<td>' + (r["Message Body"] || r.messageBody || '') + '</td>' +
+                     '<td>' + (r.Action || r.action || '') + '</td></tr>');
         });
         doc.write('</table>');
     }


### PR DESCRIPTION
## Summary
- show rider email responses in admin dashboard
- return recent email responses from AppServices

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ae6fe9af483239a69c07264502309