### PR TITLE
Add New Requests stat on admin dashboard

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -518,6 +518,14 @@ function getAdminDashboardData() {
     
     const admins = getAdminUsersSafe();
     const dispatchers = getDispatcherUsersSafe();
+
+    // Calculate new requests with status 'New'
+    let newRequests = 0;
+    try {
+      newRequests = requests.filter(r => String(r.status || r['Status']).trim() === 'New').length;
+    } catch (e) {
+      console.log('⚠️ Error calculating new requests:', e.message);
+    }
     
     const today = new Date();
     const todayStr = today.toDateString();
@@ -603,7 +611,8 @@ function getAdminDashboardData() {
       todaysEscorts: todaysEscorts,
       unassignedEscorts: unassignedEscorts,
       pendingAssignments: pendingAssignments,
-      threeDayEscorts: threeDayEscorts
+      threeDayEscorts: threeDayEscorts,
+      newRequests: newRequests
     };
     
     console.log('✅ Admin dashboard data:', result);
@@ -622,7 +631,8 @@ function getAdminDashboardData() {
       todaysEscorts: 0,
       unassignedEscorts: 0,
       pendingAssignments: 0,
-      threeDayEscorts: 0
+      threeDayEscorts: 0,
+      newRequests: 0
     };
   }
 }

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -347,6 +347,10 @@
         <!-- Quick Stats -->
         <div class="quick-stats">
             <div class="quick-stat">
+                <div class="quick-stat-number" id="newRequests">-</div>
+                <div class="quick-stat-label">New Requests</div>
+            </div>
+            <div class="quick-stat">
                 <div class="quick-stat-number" id="todaysEscorts">-</div>
                 <div class="quick-stat-label">Today's Escorts</div>
             </div>
@@ -519,6 +523,7 @@
                 document.getElementById('pendingNotifications').textContent = data.pendingNotifications || 0;
 
                 // Update quick stats
+                document.getElementById('newRequests').textContent = data.newRequests || 0;
                 document.getElementById('todaysEscorts').textContent = data.todaysEscorts || 0;
                 document.getElementById('threeDayEscorts').textContent = data.threeDayEscorts || 0;
                 document.getElementById('unassignedEscorts').textContent = data.unassignedEscorts || 0;
@@ -823,7 +828,8 @@ function displayEmailResponses(responses) {
                 pendingNotifications: 3,
                 todaysEscorts: 12,
                 threeDayEscorts: 5,
-                unassignedEscorts: 2
+                unassignedEscorts: 2,
+                newRequests: 4
             };
         }
 


### PR DESCRIPTION
## Summary
- show count of `New` requests on the admin dashboard
- support demo data for this new stat
- compute `newRequests` in `getAdminDashboardData`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685aea017e508323ad29dfe0c85d359a