### PR TITLE
Link new requests stat to new requests page

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -346,7 +346,7 @@
 
         <!-- Quick Stats -->
         <div class="quick-stats">
-            <div class="quick-stat">
+            <div class="quick-stat" onclick="openNewRequests()" style="cursor:pointer">
                 <div class="quick-stat-number" id="newRequests">-</div>
                 <div class="quick-stat-label">New Requests</div>
             </div>
@@ -615,6 +615,12 @@
         function openAuthSetup() {
             getDeployedUrl(function(baseUrl) {
                 window.open(baseUrl + '?page=auth-setup', '_blank');
+            });
+        }
+
+        function openNewRequests() {
+            getDeployedUrl(function(baseUrl) {
+                window.open(baseUrl + '?page=requests&status=New', '_top');
             });
         }
 


### PR DESCRIPTION
## Summary
- turn the New Requests quick stat into a clickable item
- add `openNewRequests` helper to route to requests page pre-filtered by status

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685aec2dbef08323969a9b72b24a7934