### PR TITLE
Fix request filter initialization

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -672,9 +672,10 @@
     document.addEventListener('DOMContentLoaded', function() {
         const params = new URLSearchParams(window.location.search);
         const statusParam = params.get('status');
-        if (statusParam) {
-            const statusFilter = document.getElementById('statusFilter');
-            if (statusFilter) {
+        const statusFilter = document.getElementById('statusFilter');
+        if (statusFilter) {
+            statusFilter.addEventListener('change', loadPageData);
+            if (statusParam) {
                 statusFilter.value = statusParam;
             }
         }
@@ -691,7 +692,6 @@
         }
 
         loadPageData();
-        document.getElementById('statusFilter').addEventListener('change', loadPageData);
         const completedCheckbox = document.getElementById('showCompleted');
         if (completedCheckbox) {
             completedCheckbox.addEventListener('change', loadPageData);


### PR DESCRIPTION
## Summary
- initialize status filter earlier in requests page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685aed6ba57c8323aad3e57c1dba40fa