### PR TITLE
Fix navigation fallback for Assign Riders

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -1376,7 +1376,8 @@ function navigateTo(page, params = {}) {
         google.script.run
             .withSuccessHandler(openUrl)
             .withFailureHandler(function() {
-                var fallbackBase = window.location.origin + window.location.pathname;
+                var basePath = window.location.origin + window.location.pathname.replace(/[^/]*$/, '');
+                var fallbackBase = basePath + (page === 'dashboard' ? 'index.html' : page + '.html');
                 openUrl(fallbackBase);
             })
             .getWebAppUrl();


### PR DESCRIPTION
## Summary
- ensure fallback path for navigating to assignments page is correct when `getWebAppUrl` fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bdb250ccc8323b24d23a056bc51cd