### PR TITLE
Fix part-time rider update mapping

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -434,8 +434,13 @@ function updateRider(riderData) {
       normalizedData['parttimerider'] ||
       normalizedData['part time rider'] ||
       normalizedData['parttime'];
+
     if (normalizedPartTime !== undefined) {
+      // Ensure we map the value to all normalized variations so the header match
+      // succeeds regardless of the column name used in the sheet.
       normalizedData['part time'] = normalizedPartTime;
+      normalizedData['part time rider'] = normalizedPartTime;
+      normalizedData['parttimerider'] = normalizedPartTime;
     }
 
     // Create updated row array using normalized matching


### PR DESCRIPTION
## Summary
- ensure updateRider applies part-time value regardless of column name used

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bdf2ec3208323a1b64bb225367737