### PR TITLE
Fix New Requests navigation when running locally

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -619,7 +619,12 @@
         }
 
         function openNewRequests() {
-            navigateTo('requests', { status: 'New' });
+            var isLocal = window.location.hostname === 'localhost' || window.location.protocol === 'file:';
+            if (isLocal) {
+                window.location.assign('requests.html?status=New');
+            } else {
+                navigateTo('requests', { status: 'New' });
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- ensure the "New Requests" quick stat works locally

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d3229acd88323891905001ff8f033