### PR TITLE
Fix New Requests filter

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -439,6 +439,7 @@
             <label><strong>Filter:</strong></label>
             <select id="statusFilter">
                 <option value="All">All Requests</option>
+                <option value="New">New</option>
                 <option value="Unassigned">Unassigned</option>
                 <option value="Assigned">Assigned</option>
             </select>


### PR DESCRIPTION
## Summary
- allow filtering by **New** on the requests page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d4352498c8323960431512cc65261