### PR TITLE
Fix Twilio API whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a Google Apps Script project used to manage ride schedu
    - From the Apps Script editor click **Services** > **+** and enable *Gmail API*.
    - In the linked Google Cloud project also enable the *Gmail API*.
 3. Copy all `.gs` and `.html` files from this repo into your project along with the `appsscript.json`.
+4. In `appsscript.json` add `https://api.twilio.com/` to the `urlFetchWhitelist` section so the script can call the Twilio API.
 
 ## OAuth scopes
 

--- a/appsscript.json
+++ b/appsscript.json
@@ -26,6 +26,7 @@
   },
   "urlFetchWhitelist": [
     "https://script.google.com/",
-    "https://accounts.google.com/"
+    "https://accounts.google.com/",
+    "https://api.twilio.com/"
   ]
 }


### PR DESCRIPTION
## Summary
- allow calls to Twilio in the Apps Script manifest
- mention Twilio whitelist step in the setup docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861b5612eec8323a2c583f13a865912