### PR TITLE
Centralize name extraction helper

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -736,26 +736,6 @@ function getUserManagementData() {
   }
 }
 /**
- * Extract name from email address as fallback
- */
-function extractNameFromEmail(email) {
-  if (!email) return 'User';
-  
-  try {
-    // Get part before @
-    const localPart = email.split('@')[0];
-    
-    // Split by dots or underscores and capitalize
-    const nameParts = localPart.split(/[._]/).map(part => 
-      part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
-    );
-    
-    return nameParts.join(' ');
-  } catch (error) {
-    return 'User';
-  }
-}
-/**
  * 🔐 COMPLETE AUTHENTICATION FUNCTIONS
  * Add these to your Authentication.js file (or Code.js if you prefer)
  * These are the missing functions that are causing the errors
@@ -927,22 +907,7 @@ function viewAuthTrace() {
 
 
 
-/**
- * Extract name from email address as fallback
- */
-function extractNameFromEmail(email) {
-  if (!email) return 'User';
-  
-  try {
-    const localPart = email.split('@')[0];
-    const nameParts = localPart.split(/[._]/).map(part => 
-      part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
-    );
-    return nameParts.join(' ');
-  } catch (error) {
-    return 'User';
-  }
-}
+
 
 /**
  * Safe wrapper for getting rider by Google email

--- a/Code.gs
+++ b/Code.gs
@@ -7620,22 +7620,7 @@ function getUserManagementData() {
   }
 }
 
-/**
- * Extract name from email for display
- */
-function extractNameFromEmail(email) {
-  if (!email) return 'User';
-  
-  try {
-    const localPart = email.split('@')[0];
-    const nameParts = localPart.split(/[._]/).map(part => 
-      part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
-    );
-    return nameParts.join(' ');
-  } catch (error) {
-    return 'User';
-  }
-}
+
 
 /**
  * Get recent system activity

--- a/CoreUtils.gs
+++ b/CoreUtils.gs
@@ -472,6 +472,24 @@ function getSmsGatewayEmail(phone, carrier) {
 }
 
 /**
+ * Extract name from email address as fallback.
+ * @param {string} email The email address.
+ * @return {string} A displayable name extracted from the email.
+ */
+function extractNameFromEmail(email) {
+  if (!email) return 'User';
+  try {
+    const localPart = email.split('@')[0];
+    const nameParts = localPart.split(/[._]/).map(part =>
+      part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+    );
+    return nameParts.join(' ');
+  } catch (error) {
+    return 'User';
+  }
+}
+
+/**
  * Tests basic server-side connectivity and script functionality.
  * @return {object} An object containing a timestamp, active spreadsheet name, sheet count, and server status.
  */


### PR DESCRIPTION
## Summary
- deduplicate `extractNameFromEmail` function
- reuse shared helper in AccessControl and main code

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862a0569d0c8323b52910dea47c82d3