### PR TITLE
Add Node & App Script .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node dependencies
+node_modules/
+
+# Google Apps Script clasp backups
+.clasp.json.*
+!.clasp.json
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Logs
+npm-debug.log*


### PR DESCRIPTION
## Summary
- add `.gitignore` for node_modules, clasp backups, and OS-specific files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862a066d5dc8323b592ba6635c4bc92