### PR TITLE
Replace eval checks with direct references

### DIFF
--- a/temputils.gs
+++ b/temputils.gs
@@ -45,7 +45,7 @@ function diagnoseBlankPageIssue() {
     
     requiredFunctions.forEach(funcName => {
       try {
-        const func = eval(funcName);
+        const func = this[funcName];
         functionTests[funcName] = typeof func === 'function' ? 'EXISTS' : 'NOT_FUNCTION';
         console.log(`   ${functionTests[funcName] === 'EXISTS' ? '✅' : '❌'} ${funcName}`);
       } catch (e) {
@@ -979,7 +979,7 @@ function diagnoseDashboardStats() {
     
     countFunctions.forEach(funcName => {
       try {
-        const func = eval(funcName);
+        const func = this[funcName];
         if (typeof func === 'function') {
           const count = func();
           results.countFunctions[funcName] = { success: true, count: count };
@@ -1415,8 +1415,8 @@ function testIndividualCountFunctions() {
   functions.forEach(funcName => {
     try {
       console.log(`\n--- Testing ${funcName} ---`);
-      const func = eval(funcName);
-      
+      const func = this[funcName];
+
       if (typeof func === 'function') {
         const result = func();
         console.log(`Result: ${result} (type: ${typeof result})`);


### PR DESCRIPTION
## Summary
- remove `eval` based function checks in the utilities
- use `this[funcName]` instead for diagnostics

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862a0675498832398b7a4c32105a9b0