### PR TITLE
Add past filter on assignments page

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -452,6 +452,11 @@
             margin-bottom: 1rem;
         }
 
+        .past-toggle {
+            text-align: center;
+            margin-bottom: 1rem;
+        }
+
         .filter-tab {
             padding: 0.5rem 1rem;
             border: 2px solid #ecf0f1;
@@ -541,6 +546,10 @@
                     <div class="filter-tab" data-status="Assigned">Assigned</div>
                 </div>
 
+                <div class="past-toggle">
+                    <label><input type="checkbox" id="showPast"> Past</label>
+                </div>
+
                 <div id="requestsList">
                     <div class="loading">Loading requests...</div>
                 </div>
@@ -621,6 +630,8 @@
         loadingTimeout: 15000,
         dateFilter: 'all'
     };
+
+    var showPast = false;
 
     // The duplicate declarations of preselectedRequestId and preselectAttempted that were here previously should be removed by this change.
     // var currentRequests = []; ... etc. will remain as is.
@@ -1209,6 +1220,14 @@ if (!document.getElementById('debug-styles')) {
                 loadRidersWithAvailability(availCheckbox.checked);
             });
         }
+
+        var pastCheckbox = document.getElementById('showPast');
+        if (pastCheckbox) {
+            pastCheckbox.addEventListener('change', function() {
+                showPast = pastCheckbox.checked;
+                filterRequests();
+            });
+        }
     }
 
     /**
@@ -1254,7 +1273,19 @@ if (!document.getElementById('debug-styles')) {
                 }
             }
 
-            return matchesSearch && matchesStatus && matchesDate && ['New', 'Pending', 'Assigned', 'Unassigned'].indexOf(request.status) !== -1;
+            var matchesPast = true;
+            if (!showPast) {
+                try {
+                    var rDate = new Date(request.eventDate);
+                    var todayStart = new Date();
+                    todayStart.setHours(0,0,0,0);
+                    matchesPast = rDate >= todayStart;
+                } catch (e) {
+                    matchesPast = true;
+                }
+            }
+
+            return matchesSearch && matchesStatus && matchesDate && matchesPast && ['New', 'Pending', 'Assigned', 'Unassigned'].indexOf(request.status) !== -1;
         });
 
         renderFilteredRequests(filtered);


### PR DESCRIPTION
## Summary
- add a Past checkbox to filter requests before today
- style past checkbox and add logic to enable filtering

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862a27b8a9c8323b50ade011494f205