### PR TITLE
Add total hours stat to reports

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2771,16 +2771,19 @@ function generateReportData(filters) {
       });
 
       if (totalHours > 0) {
-        riderHours.push({ name: riderName, hours: Math.round(totalHours * 100) / 100 });
+      riderHours.push({ name: riderName, hours: Math.round(totalHours * 100) / 100 });
       }
-    });
+      });
 
-    const reportData = {
+    const totalRiderHours = riderHours.reduce(function(sum, r) { return sum + r.hours; }, 0);
+
+     const reportData = {
       summary: {
         totalRequests: totalRequests,
         completedRequests: completedRequests,
         activeRiders: activeRiders,
-        avgCompletionRate: riderPerformance.length > 0 ? Math.round(riderPerformance.reduce((sum, r) => sum + r.completionRate, 0) / riderPerformance.length) : 0
+        avgCompletionRate: riderPerformance.length > 0 ? Math.round(riderPerformance.reduce(function(sum, r){return sum + r.completionRate;}, 0) / riderPerformance.length) : 0,
+        totalHoursWorked: Math.round(totalRiderHours * 100) / 100
       },
       charts: {
         requestVolume: {

--- a/reports.html
+++ b/reports.html
@@ -279,6 +279,10 @@
             border-left-color: #e74c3c;
         }
 
+        .summary-card.info {
+            border-left-color: #1abc9c;
+        }
+
         .filter-section {
             background: #f8f9fa;
             border-radius: 10px;
@@ -432,6 +436,10 @@
             <div class="summary-card warning">
                 <div class="metric-value" id="activeRiders">-</div>
                 <div class="metric-label">Active Riders</div>
+            </div>
+            <div class="summary-card info">
+                <div class="metric-value" id="totalHoursWorked">-</div>
+                <div class="metric-label">Total Hours Worked</div>
             </div>
         </div>
 
@@ -681,6 +689,7 @@
             document.getElementById('totalRequests').textContent = summary.totalRequests || 0;
             document.getElementById('completedRequests').textContent = summary.completedRequests || 0;
             document.getElementById('activeRiders').textContent = summary.activeRiders || 0;
+            document.getElementById('totalHoursWorked').textContent = summary.totalHoursWorked || 0;
         }
 
         function updateCharts(charts) {
@@ -747,7 +756,7 @@
             hideLoading();
             console.log('Using fallback data for reports');
             var data = {
-                summary: { totalRequests: 0, completedRequests: 0, activeRiders: 0 },
+                summary: { totalRequests: 0, completedRequests: 0, activeRiders: 0, totalHoursWorked: 0 },
                 charts: {},
                 tables: {}
             };


### PR DESCRIPTION
## Summary
- compute total rider hours in report generation
- display Total Hours Worked card on reports page
- update summary stats to show rider hours

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862a64f8e4c8323a296cb3a6423df21