### PR TITLE
Fix report date parsing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2760,9 +2760,9 @@ function generateReportData(filters) {
     const ridersData = getRidersData();
     
     // Filter data based on date range
-    const startDate = new Date(filters.startDate);
+    const startDate = parseDateString(filters.startDate) || new Date(1970, 0, 1);
     startDate.setHours(0,0,0,0);
-    const endDate = new Date(filters.endDate);
+    const endDate = parseDateString(filters.endDate) || new Date();
     endDate.setHours(23, 59, 59, 999);
     
     const filteredRequests = requestsData.data.filter(request => {


### PR DESCRIPTION
## Summary
- fix date parsing in `generateReportData` so missing filters don't zero out results

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862c9e496708323929b55b67c7d7597