### PR TITLE
Fix escort hours report display

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2770,9 +2770,7 @@ function generateReportData(filters) {
         }
       });
 
-      if (totalHours > 0) {
-        riderHours.push({ name: riderName, hours: Math.round(totalHours * 100) / 100 });
-      }
+      riderHours.push({ name: riderName, hours: Math.round(totalHours * 100) / 100 });
     });
 
     const reportData = {

--- a/reports.html
+++ b/reports.html
@@ -715,6 +715,9 @@
                     var r = tables.riderHours[i];
                     hoursRows += '<tr><td>' + r.name + '</td><td>' + r.hours + '</td></tr>';
                 }
+                if (tables.riderHours.length === 0) {
+                    hoursRows = '<tr><td colspan="2" style="text-align:center;">No hours recorded</td></tr>';
+                }
                 var hoursTable = '<table class="stats-table"><thead><tr><th>Rider</th><th>Hours</th></tr></thead><tbody>' + hoursRows + '</tbody></table>';
                 document.getElementById('riderHoursTable').innerHTML = hoursTable;
             }


### PR DESCRIPTION
## Summary
- ensure escort hours are included even when zero
- show an explicit "No hours recorded" message when no rider hours exist

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68630f41441c8323af2a749835df7d32