### PR TITLE
Add rider activity breakdown to reports

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2743,13 +2743,14 @@ function generateReportData(filters) {
       }
     });
 
-    // Calculate total escort hours per rider within the period
+    // Calculate escort count and total hours per rider within the period
     const riderHours = [];
     ridersData.data.forEach(rider => {
       const riderName = getColumnValue(rider, ridersData.columnMap, CONFIG.columns.riders.name);
       if (!riderName) return;
 
       let totalHours = 0;
+      let escorts = 0;
 
       assignmentsData.data.forEach(assignment => {
         const assignmentRider = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.riderName);
@@ -2762,6 +2763,7 @@ function generateReportData(filters) {
         }
 
         if (assignmentRider === riderName && status === 'Completed' && dateMatches) {
+          escorts++;
           const start = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime));
           const end = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime));
           if (start && end && end > start) {
@@ -2770,7 +2772,11 @@ function generateReportData(filters) {
         }
       });
 
-      riderHours.push({ name: riderName, hours: Math.round(totalHours * 100) / 100 });
+      riderHours.push({
+        name: riderName,
+        escorts: escorts,
+        hours: Math.round(totalHours * 100) / 100
+      });
     });
 
     const reportData = {

--- a/reports.html
+++ b/reports.html
@@ -466,9 +466,9 @@
             </div>
 
 
-            <!-- Monthly Escort Hours -->
+            <!-- Rider Activity -->
             <div class="report-card">
-                <h3 class="report-title">⏰ Monthly Escort Hours</h3>
+                <h3 class="report-title">⏰ Rider Activity</h3>
                 <div id="riderHoursTable">
                     <div class="loading">Loading hours...</div>
                 </div>
@@ -713,12 +713,13 @@
                 var hoursRows = '';
                 for (var i = 0; i < tables.riderHours.length; i++) {
                     var r = tables.riderHours[i];
-                    hoursRows += '<tr><td>' + r.name + '</td><td>' + r.hours + '</td></tr>';
+                    var escorts = (r.escorts !== undefined) ? r.escorts : '';
+                    hoursRows += '<tr><td>' + r.name + '</td><td>' + escorts + '</td><td>' + r.hours + '</td></tr>';
                 }
                 if (tables.riderHours.length === 0) {
-                    hoursRows = '<tr><td colspan="2" style="text-align:center;">No hours recorded</td></tr>';
+                    hoursRows = '<tr><td colspan="3" style="text-align:center;">No hours recorded</td></tr>';
                 }
-                var hoursTable = '<table class="stats-table"><thead><tr><th>Rider</th><th>Hours</th></tr></thead><tbody>' + hoursRows + '</tbody></table>';
+                var hoursTable = '<table class="stats-table"><thead><tr><th>Rider</th><th>Escorts</th><th>Hours</th></tr></thead><tbody>' + hoursRows + '</tbody></table>';
                 document.getElementById('riderHoursTable').innerHTML = hoursTable;
             }
 


### PR DESCRIPTION
## Summary
- compute escort counts in `generateReportData`
- show escorts and hours per rider on the Reports page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863246e834c8323ad9f99a528e60b26