### PR TITLE
Fix assignments page data loading

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -2522,15 +2522,32 @@ function getPageDataForDashboard(user) {
  * @param {string} [requestIdToLoad] - Optional request ID to pre-select
  * @return {object} Consolidated data object with user, requests, riders, and optional initial request details
  */
-function getPageDataForAssignments(user, requestIdToLoad) { // Added user parameter
+function getAssignmentsPageData(requestIdToLoad) {
   try {
-    console.log('🔄 Loading assignments page data for user:', user ? user.email : 'Unknown', requestIdToLoad ? `Pre-selecting: ${requestIdToLoad}` : '');
+    const auth = authenticateAndAuthorizeUser();
+    if (!auth.success) {
+      return {
+        success: false,
+        error: auth.error || 'UNAUTHORIZED',
+        user: auth.user || {
+          name: 'User',
+          email: '',
+          roles: ['unauthorized'],
+          permissions: []
+        },
+        requests: [],
+        riders: [],
+        initialRequestDetails: null,
+        assignmentOrder: []
+      };
+    }
+    const user = auth.user;
 
-    // const auth = authenticateAndAuthorizeUser(); // Assuming user is already authenticated
-    // if (!auth.success) {
-    //   return { success: false, error: auth.error || 'UNAUTHORIZED', user: auth.user || { name: 'User', email: '', roles: ['unauthorized'] }, requests: [], riders: [], initialRequestDetails: null, assignmentOrder: [] };
-    // }
-    // const user = auth.user;
+    console.log(
+      '🔄 Loading assignments page data for user:',
+      user ? user.email : 'Unknown',
+      requestIdToLoad ? `Pre-selecting: ${requestIdToLoad}` : ''
+    );
 
     // Fetch raw data once
     const rawRequestsData = getRequestsData(true);

--- a/assignments.html
+++ b/assignments.html
@@ -656,7 +656,7 @@
 
     /**
      * Loads all necessary data for the assignments page by calling the consolidated
-     * server-side function `getPageDataForAssignments`.
+     * server-side function `getAssignmentsPageData`.
      * Passes a requestId from URL parameters if present.
      * @return {void}
      */
@@ -669,7 +669,7 @@
             google.script.run
                 .withSuccessHandler(handleAssignmentsDataSuccess)
                 .withFailureHandler(handleAssignmentsDataFailure)
-                .getPageDataForAssignments(requestIdToLoad);
+                .getAssignmentsPageData(requestIdToLoad);
         } else {
             console.log('⚠️ Google Apps Script not available for assignments page.');
             handleAssignmentsDataFailure({ message: "Google Apps Script not available." });


### PR DESCRIPTION
## Summary
- secure server-side assignments data fetch
- rename server function to avoid parameter mismatch
- update client page to call the new function

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863330ca42083238e48941192fde9cb