### PR TITLE
Fix missing calendar OAuth scope

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -18,7 +18,8 @@
     "https://www.googleapis.com/auth/userinfo.profile",
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/script.webapp.deploy"
+    "https://www.googleapis.com/auth/script.webapp.deploy",
+    "https://www.googleapis.com/auth/calendar"
   ],
   "webapp": {
     "executeAs": "USER_DEPLOYING",


### PR DESCRIPTION
## Summary
- allow access to CalendarApp by including the Google Calendar OAuth scope

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68633a275260832397c5308004f158ed