### PR TITLE
Fix escort hours reporting issue

### DIFF
--- a/ACTUAL_COMPLETION_FIX_SUMMARY.md
+++ b/ACTUAL_COMPLETION_FIX_SUMMARY.md
@@ -1,0 +1,159 @@
+# Reports Page - Actual Completion Time Fix ✅
+
+## Updated Approach Summary
+Based on your feedback, the fix has been updated to **focus on actual completion data** rather than loose estimates. The system now prioritizes real completion times and only uses realistic estimates when the event date has passed but actual data isn't recorded.
+
+## Key Changes Made
+
+### 1. **Priority-Based Data Usage**
+```
+Priority 1: Actual Duration (Hours) field
+Priority 2: Actual Start Time + Actual End Time calculation  
+Priority 3: Realistic estimates (only for past events without data)
+```
+
+### 2. **Realistic Hour Estimates** (Your Specifications)
+- **Funeral**: 0.5 hours (was 1.5)
+- **Wedding**: 2.5 hours (unchanged)
+- **VIP**: 4.0 hours (was 2.0)
+- **Float Movement**: 4.0 hours (was 3.0)
+- **Other**: 2.0 hours (default)
+
+### 3. **Strict Completion Criteria**
+Only counts assignments where:
+- Status = "Completed" **OR**
+- Event date has passed + rider was assigned (indicating work should have been done)
+
+No longer counts future assignments or those without assignment status.
+
+## New Assignments Sheet Columns Added
+
+The system now expects these new columns in the Assignments sheet:
+
+1. **`Actual Start Time`** - When the escort actually began
+2. **`Actual End Time`** - When the escort actually ended  
+3. **`Actual Duration (Hours)`** - Direct entry in decimal hours (e.g., 2.5)
+
+## Implementation Steps
+
+### Step 1: Add New Columns (Automatic)
+Run this function to set up the new columns:
+```javascript
+setupActualCompletionTimeColumns()
+```
+
+This will:
+- Add the three new columns to your Assignments sheet
+- Format them properly with validation
+- Provide usage instructions
+
+### Step 2: Test the Fix
+Run this function to verify everything works:
+```javascript
+testActualCompletionReportsFix()
+```
+
+This will:
+- Analyze your current data
+- Show what's being counted vs. estimated
+- Provide specific guidance based on your data
+
+### Step 3: Start Recording Actual Times
+For future escorts, record completion data:
+- **Option A**: Fill "Actual Start Time" and "Actual End Time"
+- **Option B**: Fill just "Actual Duration (Hours)" (easier)
+
+## How the New Logic Works
+
+### For Reports Page:
+1. **Scans all assignments** in date range
+2. **Matches rider names** (case-insensitive)
+3. **Checks completion criteria**:
+   - Status = "Completed", OR
+   - Event date passed + rider was assigned
+4. **Calculates hours**:
+   - Uses "Actual Duration" if recorded
+   - Uses "Actual Start/End Times" if recorded
+   - Uses realistic estimate if event passed but no actual data
+   - Uses 0 hours if event hasn't occurred yet
+
+### Data Sources Hierarchy:
+```
+🥇 Actual Duration (Hours) field
+🥈 Actual Start Time + Actual End Time  
+🥉 Realistic estimate (past events only)
+❌ No hours (future events)
+```
+
+## Testing Results to Expect
+
+### Ideal Scenario (With Actual Data):
+```
+✅ SUCCESS: Hours calculated using actual completion data where available!
+- Assignments with recorded duration: 15
+- Assignments with actual start/end times: 8  
+- Total hours: 45.5 (from actual data)
+```
+
+### Transitional Scenario (Estimates for Past Events):
+```
+⚠️ Hours are estimated only. For accurate reporting, start recording actual completion times
+- Past events that should have completion data: 12
+- Assignments missing actual completion data: 12
+- Total hours: 28.0 (from estimates)
+```
+
+### No Data Scenario:
+```
+⚠️ No hours calculated. Check if: 1) Assignments exist with past event dates, 2) Assignments have "Completed" status or past event dates with assigned riders
+```
+
+## Files Modified
+
+1. **`Config.gs`** - Added new column definitions
+2. **`Code.gs`** - Updated all hour calculation functions:
+   - `generateReportData()`
+   - `generateRiderActivityReport()` 
+   - `generateExecutiveSummary()`
+3. **`Code.gs`** - Added new functions:
+   - `getRealisticEscortHours()` (replaces old estimate function)
+   - `setupActualCompletionTimeColumns()` (setup helper)
+   - `testActualCompletionReportsFix()` (updated test)
+   - `debugAssignmentDataForReports()` (updated diagnostics)
+
+## Workflow for Data Entry
+
+### For Completed Escorts:
+1. **Rider completes escort**
+2. **Update assignment status** to "Completed"
+3. **Record actual time** using ONE of these methods:
+   - Enter decimal hours in "Actual Duration (Hours)" 
+   - Enter "Actual Start Time" and "Actual End Time"
+4. **Reports automatically use** actual data
+
+### For Missing Historical Data:
+- System will use realistic estimates for past events
+- Gradually replace estimates with actual data as you record it
+- Reports will show mix of actual and estimated hours
+
+## Benefits of This Approach
+
+✅ **Accurate Data**: Prioritizes real completion times over estimates
+✅ **Flexible Entry**: Multiple ways to record actual times  
+✅ **Realistic Fallbacks**: Conservative estimates based on your specifications
+✅ **Clear Distinction**: Shows what's actual vs. estimated in test results
+✅ **No Future Padding**: Won't count future/unworked assignments
+✅ **Easy Migration**: Works with existing data, improves as you add actual times
+
+## Next Steps
+
+1. **Run `setupActualCompletionTimeColumns()`** to add the new columns
+2. **Run `testActualCompletionReportsFix()`** to see current state
+3. **Start recording actual completion times** for new escorts
+4. **Check reports page** - should now show meaningful hours
+5. **Gradually backfill historical data** if desired for accuracy
+
+---
+**Status**: ✅ Ready for implementation
+**Focus**: Actual completion data over estimates
+**Fallback**: Realistic estimates (0.5-4.0 hours) for past events only

--- a/Code.gs
+++ b/Code.gs
@@ -2762,30 +2762,55 @@ function generateReportData(filters) {
           dateMatches = eventDate >= startDate && eventDate <= endDate;
         }
 
-        // More flexible rider name and status matching
+        // Match rider names (case-insensitive, trimmed)
         if (assignmentRider && riderName && 
             assignmentRider.toString().trim().toLowerCase() === riderName.toString().trim().toLowerCase() && 
             dateMatches) {
           
-          // More flexible status checking - count assignments that were actually worked
+          // Only count assignments that have actually been worked (past event date or completed)
           const statusLower = (status || '').toLowerCase().trim();
-          const countableStatuses = ['completed', 'in progress', 'assigned', 'confirmed', 'en route'];
+          const eventDateObj = eventDate instanceof Date ? eventDate : new Date(eventDate);
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
           
-          if (countableStatuses.includes(statusLower)) {
+          // Count if:
+          // 1. Status is 'Completed', OR
+          // 2. Event date has passed and rider was assigned (should have completion data)
+          const isCompleted = statusLower === 'completed';
+          const eventHasPassed = !isNaN(eventDateObj.getTime()) && eventDateObj < today;
+          const wasAssigned = ['assigned', 'confirmed', 'en route', 'in progress'].includes(statusLower);
+          
+          if (isCompleted || (eventHasPassed && wasAssigned)) {
             escorts++;
             
-            const start = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime));
-            const end = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime));
+            // Priority 1: Use actual completion times if available
+            const actualStart = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualStartTime);
+            const actualEnd = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualEndTime);
+            const actualDuration = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualDuration);
             
-            if (start && end && end > start) {
-              totalHours += (end.getTime() - start.getTime()) / (1000 * 60 * 60);
-            } else {
-              // Fallback: add estimated hours for assignments without valid time data
-              // This addresses the common issue where time data is missing or invalid
-              const estimatedHours = estimateEscortHoursByType(assignment, assignmentsData.columnMap);
-              totalHours += estimatedHours;
-              console.log(`Used estimated ${estimatedHours} hours for assignment without valid times: ${assignmentRider}`);
+            let hoursToAdd = 0;
+            
+            if (actualDuration && !isNaN(parseFloat(actualDuration))) {
+              // Use recorded duration if available
+              hoursToAdd = parseFloat(actualDuration);
+              console.log(`Using recorded duration: ${hoursToAdd} hours for ${assignmentRider}`);
+            } else if (actualStart && actualEnd) {
+              // Calculate from actual start/end times
+              const startTime = parseTimeString(actualStart);
+              const endTime = parseTimeString(actualEnd);
+              if (startTime && endTime && endTime > startTime) {
+                hoursToAdd = (endTime.getTime() - startTime.getTime()) / (1000 * 60 * 60);
+                console.log(`Calculated from actual times: ${hoursToAdd} hours for ${assignmentRider}`);
+              }
             }
+            
+            // If no actual data available and event has passed, use realistic estimates
+            if (hoursToAdd === 0 && eventHasPassed) {
+              hoursToAdd = getRealisticEscortHours(assignment, assignmentsData.columnMap);
+              console.log(`Using realistic estimate: ${hoursToAdd} hours for ${assignmentRider} (event has passed)`);
+            }
+            
+            totalHours += hoursToAdd;
           }
         }
       });
@@ -2830,23 +2855,24 @@ function generateReportData(filters) {
 }
 
 /**
- * Helper function to estimate escort hours when actual times aren't available
+ * Get realistic escort hours for completed assignments when actual data isn't available
+ * Only use for assignments where the event date has passed (indicating work was done)
  * @param {Array} assignment - The assignment row data
  * @param {Object} columnMap - Column mapping for assignments
- * @return {number} Estimated hours for the escort
+ * @return {number} Realistic hours estimate based on request type
  */
-function estimateEscortHoursByType(assignment, columnMap) {
-  // Default estimates by request type (in hours)
-  const typeEstimates = {
-    'Wedding': 2.5,
-    'Funeral': 1.5,
-    'Float Movement': 3.0,
-    'VIP': 2.0,
-    'Other': 2.0
+function getRealisticEscortHours(assignment, columnMap) {
+  // Realistic hour estimates based on actual escort experience
+  const realisticEstimates = {
+    'Funeral': 0.5,        // Short, focused escorts
+    'Wedding': 2.5,        // Moderate duration with setup/ceremony/departure
+    'VIP': 4.0,           // Longer, more complex routes
+    'Float Movement': 4.0, // Extended transport/logistics
+    'Other': 2.0          // General default
   };
   
   try {
-    // Try to get the request type from the assignment's request ID
+    // Get the request type from the assignment's request ID
     const requestId = getColumnValue(assignment, columnMap, CONFIG.columns.assignments.requestId);
     
     if (requestId) {
@@ -2857,17 +2883,17 @@ function estimateEscortHoursByType(assignment, columnMap) {
       
       if (request) {
         const requestType = getColumnValue(request, requestsData.columnMap, CONFIG.columns.requests.type);
-        const estimatedHours = typeEstimates[requestType] || typeEstimates['Other'];
-        console.log(`Estimated ${estimatedHours} hours for ${requestType} escort (Request ID: ${requestId})`);
+        const estimatedHours = realisticEstimates[requestType] || realisticEstimates['Other'];
+        console.log(`Applied realistic estimate: ${estimatedHours} hours for ${requestType} escort (Request ID: ${requestId})`);
         return estimatedHours;
       }
     }
   } catch (error) {
-    console.warn('Could not estimate hours from request data:', error);
+    console.warn('Could not determine request type for realistic estimate:', error);
   }
   
   // Default fallback
-  return typeEstimates['Other'];
+  return realisticEstimates['Other'];
 }
 
 /**
@@ -2924,24 +2950,42 @@ function debugAssignmentDataForReports() {
         console.log(`  ${rider}: ${count} assignments`);
       });
     
-    // Check time data availability
-    console.log('\n=== TIME DATA AVAILABILITY ===');
-    let assignmentsWithTimes = 0;
-    let assignmentsWithoutTimes = 0;
+    // Check actual completion data availability
+    console.log('\n=== ACTUAL COMPLETION DATA AVAILABILITY ===');
+    let assignmentsWithActualTimes = 0;
+    let assignmentsWithActualDuration = 0;
+    let assignmentsWithoutActualData = 0;
+    let pastEventAssignments = 0;
+    
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
     
     assignmentsData.data.forEach(assignment => {
-      const startTime = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime);
-      const endTime = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime);
+      const eventDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate);
+      const eventDateObj = eventDate instanceof Date ? eventDate : new Date(eventDate);
+      const eventHasPassed = !isNaN(eventDateObj.getTime()) && eventDateObj < today;
       
-      if (startTime && endTime) {
-        assignmentsWithTimes++;
+      if (eventHasPassed) {
+        pastEventAssignments++;
+      }
+      
+      const actualStart = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualStartTime);
+      const actualEnd = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualEndTime);
+      const actualDuration = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualDuration);
+      
+      if (actualDuration && !isNaN(parseFloat(actualDuration))) {
+        assignmentsWithActualDuration++;
+      } else if (actualStart && actualEnd) {
+        assignmentsWithActualTimes++;
       } else {
-        assignmentsWithoutTimes++;
+        assignmentsWithoutActualData++;
       }
     });
     
-    console.log(`Assignments WITH time data: ${assignmentsWithTimes}`);
-    console.log(`Assignments WITHOUT time data: ${assignmentsWithoutTimes}`);
+    console.log(`Total assignments with past event dates: ${pastEventAssignments}`);
+    console.log(`Assignments WITH actual duration recorded: ${assignmentsWithActualDuration}`);
+    console.log(`Assignments WITH actual start/end times: ${assignmentsWithActualTimes}`);
+    console.log(`Assignments WITHOUT actual completion data: ${assignmentsWithoutActualData}`);
     
     return {
       success: true,
@@ -2949,9 +2993,11 @@ function debugAssignmentDataForReports() {
       totalRiders: ridersData.data.length,
       statusDistribution: statusCounts,
       riderDistribution: riderCounts,
-      timeDataStats: {
-        withTimes: assignmentsWithTimes,
-        withoutTimes: assignmentsWithoutTimes
+      actualCompletionDataStats: {
+        pastEventAssignments: pastEventAssignments,
+        withActualDuration: assignmentsWithActualDuration,
+        withActualTimes: assignmentsWithActualTimes,
+        withoutActualData: assignmentsWithoutActualData
       }
     };
     
@@ -2965,18 +3011,18 @@ function debugAssignmentDataForReports() {
  }
 
 /**
- * Test function to verify the reports fix is working
- * This function can be run manually to test the improved rider hours calculation
- * @return {Object} Test results showing if escort hours are now being calculated
+ * Test function to verify the actual completion time-based reports fix
+ * This function tests the new logic that prioritizes actual completion data
+ * @return {Object} Test results showing if escort hours are calculated from actual data
  */
-function testReportsFixForZeroHours() {
+function testActualCompletionReportsFix() {
   try {
-    console.log('🧪 Testing Reports Fix for Zero Hours Issue...');
+    console.log('🧪 Testing Actual Completion Time Reports Fix...');
     
-    // Test with last 30 days
+    // Test with last 60 days to capture more data
     const endDate = new Date();
     const startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - 30);
+    startDate.setDate(endDate.getDate() - 60);
     
     const filters = {
       startDate: startDate.toISOString().split('T')[0],
@@ -2984,6 +3030,10 @@ function testReportsFixForZeroHours() {
     };
     
     console.log(`Testing with date range: ${filters.startDate} to ${filters.endDate}`);
+    
+    // First, run diagnostics to understand the data
+    console.log('\n🔍 Running diagnostic check...');
+    const debugInfo = debugAssignmentDataForReports();
     
     // Generate report data using the fixed function
     const reportData = generateReportData(filters);
@@ -2994,9 +3044,16 @@ function testReportsFixForZeroHours() {
     const totalHours = riderHours.reduce((sum, rider) => sum + rider.hours, 0);
     
     console.log('\n📊 TEST RESULTS:');
-    console.log(`Total riders with data: ${riderHours.length}`);
+    console.log(`Total riders with escort data: ${riderHours.length}`);
     console.log(`Total escorts counted: ${totalEscorts}`);
     console.log(`Total hours calculated: ${totalHours.toFixed(2)}`);
+    
+    // Analyze data sources
+    console.log('\n📈 DATA SOURCE ANALYSIS:');
+    console.log(`Past events that should have completion data: ${debugInfo.actualCompletionDataStats.pastEventAssignments}`);
+    console.log(`Assignments with recorded duration: ${debugInfo.actualCompletionDataStats.withActualDuration}`);
+    console.log(`Assignments with actual start/end times: ${debugInfo.actualCompletionDataStats.withActualTimes}`);
+    console.log(`Assignments missing actual completion data: ${debugInfo.actualCompletionDataStats.withoutActualData}`);
     
     if (riderHours.length > 0) {
       console.log('\n🏍️ Top 5 riders by hours:');
@@ -3005,9 +3062,15 @@ function testReportsFixForZeroHours() {
       });
     }
     
-    // Test the debug function
-    console.log('\n🔍 Running diagnostic check...');
-    const debugInfo = debugAssignmentDataForReports();
+    // Provide guidance based on results
+    let guidance = '';
+    if (totalHours === 0) {
+      guidance = '⚠️ No hours calculated. Check if: 1) Assignments exist with past event dates, 2) Assignments have "Completed" status or past event dates with assigned riders';
+    } else if (debugInfo.actualCompletionDataStats.withActualDuration === 0 && debugInfo.actualCompletionDataStats.withActualTimes === 0) {
+      guidance = '⚠️ Hours are estimated only. For accurate reporting, start recording actual completion times in the "Actual Start Time", "Actual End Time", or "Actual Duration (Hours)" columns';
+    } else {
+      guidance = '✅ SUCCESS: Hours calculated using actual completion data where available!';
+    }
     
     const testResult = {
       success: true,
@@ -3015,27 +3078,131 @@ function testReportsFixForZeroHours() {
       totalEscorts: totalEscorts,
       totalHours: parseFloat(totalHours.toFixed(2)),
       topRiders: riderHours.slice(0, 5),
-      debugInfo: debugInfo,
-      message: totalHours > 0 ? 
-        '✅ SUCCESS: Hours are now being calculated!' : 
-        '⚠️ WARNING: Still showing zero hours - check debug info'
+      dataSourceStats: debugInfo.actualCompletionDataStats,
+      statusDistribution: debugInfo.statusDistribution,
+      guidance: guidance,
+      message: guidance
     };
     
     console.log('\n📋 Final Test Result:', testResult.message);
     return testResult;
     
   } catch (error) {
-    console.error('❌ Error in testReportsFixForZeroHours:', error);
+    console.error('❌ Error in testActualCompletionReportsFix:', error);
     return {
       success: false,
       error: error.message,
       message: '❌ ERROR: Test failed - check logs for details'
     };
+    }
+}
+
+/**
+ * Helper function to add actual completion time columns to the Assignments sheet
+ * Run this once to add the necessary columns for tracking actual escort completion times
+ * @return {Object} Result of the setup operation
+ */
+function setupActualCompletionTimeColumns() {
+  try {
+    console.log('🛠️ Setting up Actual Completion Time columns in Assignments sheet...');
+    
+    const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    const assignmentsSheet = spreadsheet.getSheetByName(CONFIG.sheets.assignments);
+    
+    if (!assignmentsSheet) {
+      throw new Error('Assignments sheet not found');
+    }
+    
+    // Get existing headers
+    const lastColumn = assignmentsSheet.getLastColumn();
+    const headers = assignmentsSheet.getRange(1, 1, 1, lastColumn).getValues()[0];
+    
+    // Check which new columns need to be added
+    const newColumns = [
+      'Actual Start Time',
+      'Actual End Time', 
+      'Actual Duration (Hours)'
+    ];
+    
+    let nextColumn = lastColumn + 1;
+    const addedColumns = [];
+    
+    newColumns.forEach(columnName => {
+      if (!headers.includes(columnName)) {
+        assignmentsSheet.getRange(1, nextColumn).setValue(columnName);
+        addedColumns.push(columnName);
+        console.log(`Added column: ${columnName} at position ${nextColumn}`);
+        nextColumn++;
+      } else {
+        console.log(`Column already exists: ${columnName}`);
+      }
+    });
+    
+    // Format the new columns
+    if (addedColumns.length > 0) {
+      const newRange = assignmentsSheet.getRange(1, lastColumn + 1, 1, addedColumns.length);
+      newRange.setFontWeight('bold');
+      newRange.setBackground('#fff2cc'); // Light yellow background for new columns
+      
+      // Add data validation for duration column if it was added
+      if (addedColumns.includes('Actual Duration (Hours)')) {
+        const durationColumnIndex = headers.length + addedColumns.indexOf('Actual Duration (Hours)') + 1;
+        const durationRange = assignmentsSheet.getRange(2, durationColumnIndex, assignmentsSheet.getMaxRows() - 1, 1);
+        
+        // Set number format to 2 decimal places
+        durationRange.setNumberFormat('0.00');
+        
+        // Add note about usage
+        assignmentsSheet.getRange(1, durationColumnIndex).setNote(
+          'Enter the actual duration of the escort in decimal hours (e.g., 1.5 for 1 hour 30 minutes). ' +
+          'This will be used for accurate reporting instead of estimates.'
+        );
+      }
+    }
+    
+    console.log(`✅ Setup complete. Added ${addedColumns.length} new columns.`);
+    
+    // Instructions for users
+    const instructions = [
+      '\n📋 INSTRUCTIONS FOR TRACKING ACTUAL COMPLETION TIMES:',
+      '',
+      '1. ACTUAL START TIME: Enter the time the escort actually began (e.g., "2:15 PM")',
+      '2. ACTUAL END TIME: Enter the time the escort actually ended (e.g., "4:45 PM")',
+      '3. ACTUAL DURATION (HOURS): Enter decimal hours (e.g., "2.5" for 2 hours 30 minutes)',
+      '',
+      '💡 TIP: You only need to fill ONE of these:',
+      '   - Either fill both Actual Start Time AND Actual End Time',
+      '   - OR just fill Actual Duration (Hours)',
+      '',
+      '🎯 PRIORITY: Duration takes precedence over start/end times if both are provided',
+      '',
+      '📊 REPORTING: Reports will use actual data when available, estimates when not',
+      '   - Funeral: 0.5 hours estimate',
+      '   - Wedding: 2.5 hours estimate', 
+      '   - VIP/Float Movement: 4.0 hours estimate'
+    ];
+    
+    instructions.forEach(line => console.log(line));
+    
+    return {
+      success: true,
+      addedColumns: addedColumns,
+      message: `Successfully added ${addedColumns.length} columns. Check console for usage instructions.`,
+      instructions: instructions
+    };
+    
+  } catch (error) {
+    console.error('❌ Error setting up actual completion time columns:', error);
+    return {
+      success: false,
+      error: error.message,
+      message: 'Failed to setup completion time columns. Check logs for details.'
+    };
   }
 }
- 
- /**
-  * Generates a rider activity report for the given date range.
+  
+  /**
+   * Generates a rider activity report for the given date range.
  * @param {string} startDate Start date in YYYY-MM-DD format.
  * @param {string} endDate End date in YYYY-MM-DD format.
  * @return {object} Result object with success flag and data array.
@@ -3062,27 +3229,46 @@ function generateRiderActivityReport(startDate, endDate) {
       const rider = getColumnValue(row, assignmentsData.columnMap, CONFIG.columns.assignments.riderName);
       if (!rider) return;
 
-      // More flexible status checking - count assignments that were actually worked
+      // Only count assignments that have actually been worked
       const statusLower = (status || '').toLowerCase().trim();
-      const countableStatuses = ['completed', 'in progress', 'assigned', 'confirmed', 'en route'];
+      const eventDateObj = eventDate instanceof Date ? eventDate : new Date(eventDate);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
       
-      if (!countableStatuses.includes(statusLower)) return;
-
-      const startTime = parseTimeString(getColumnValue(row, assignmentsData.columnMap, CONFIG.columns.assignments.startTime));
-      const endTime = parseTimeString(getColumnValue(row, assignmentsData.columnMap, CONFIG.columns.assignments.endTime));
+      const isCompleted = statusLower === 'completed';
+      const eventHasPassed = !isNaN(eventDateObj.getTime()) && eventDateObj < today;
+      const wasAssigned = ['assigned', 'confirmed', 'en route', 'in progress'].includes(statusLower);
+      
+      if (!(isCompleted || (eventHasPassed && wasAssigned))) return;
 
       if (!riderMap[rider]) {
         riderMap[rider] = { escorts: 0, hours: 0 };
       }
       riderMap[rider].escorts++;
       
-      if (startTime && endTime && endTime > startTime) {
-        riderMap[rider].hours += (endTime.getTime() - startTime.getTime()) / (1000 * 60 * 60);
-      } else {
-        // Use estimated hours when actual times aren't available
-        const estimatedHours = estimateEscortHoursByType(row, assignmentsData.columnMap);
-        riderMap[rider].hours += estimatedHours;
+      // Priority 1: Use actual completion data
+      const actualStart = getColumnValue(row, assignmentsData.columnMap, CONFIG.columns.assignments.actualStartTime);
+      const actualEnd = getColumnValue(row, assignmentsData.columnMap, CONFIG.columns.assignments.actualEndTime);
+      const actualDuration = getColumnValue(row, assignmentsData.columnMap, CONFIG.columns.assignments.actualDuration);
+      
+      let hoursToAdd = 0;
+      
+      if (actualDuration && !isNaN(parseFloat(actualDuration))) {
+        hoursToAdd = parseFloat(actualDuration);
+      } else if (actualStart && actualEnd) {
+        const startTime = parseTimeString(actualStart);
+        const endTime = parseTimeString(actualEnd);
+        if (startTime && endTime && endTime > startTime) {
+          hoursToAdd = (endTime.getTime() - startTime.getTime()) / (1000 * 60 * 60);
+        }
       }
+      
+      // If no actual data and event has passed, use realistic estimates
+      if (hoursToAdd === 0 && eventHasPassed) {
+        hoursToAdd = getRealisticEscortHours(row, assignmentsData.columnMap);
+      }
+      
+      riderMap[rider].hours += hoursToAdd;
     });
 
     const data = Object.keys(riderMap).map(name => ({
@@ -3174,28 +3360,55 @@ function generateExecutiveSummary(startDate, endDate) {
 
       const status = getColumnValue(row, requestsData.columnMap, CONFIG.columns.requests.status);
       
-      // More flexible status checking for executive summary
+      // Only count requests that have been completed
       const statusLower = (status || '').toLowerCase().trim();
-      const countableStatuses = ['completed', 'in progress'];
       
-      if (countableStatuses.includes(statusLower)) {
+      if (statusLower === 'completed') {
         completed++;
-        const s = parseTimeString(getColumnValue(row, requestsData.columnMap, CONFIG.columns.requests.startTime));
-        const e = parseTimeString(getColumnValue(row, requestsData.columnMap, CONFIG.columns.requests.endTime));
-        if (s && e && e > s) {
-          totalHours += (e.getTime() - s.getTime()) / (1000 * 60 * 60);
-        } else {
-          // Estimate hours based on request type when times are not available
+        
+        // For executive summary, we need to aggregate from actual assignment hours
+        // since requests don't track actual completion times
+        const requestId = getColumnValue(row, requestsData.columnMap, CONFIG.columns.requests.id);
+        let requestHours = 0;
+        
+        // Get all assignments for this request and sum their actual hours
+        try {
+          const assignmentsData = getAssignmentsData();
+          assignmentsData.data.forEach(assignment => {
+            const assignmentRequestId = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.requestId);
+            if (assignmentRequestId === requestId) {
+              const actualDuration = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.actualDuration);
+              if (actualDuration && !isNaN(parseFloat(actualDuration))) {
+                requestHours += parseFloat(actualDuration);
+              } else {
+                // Use realistic estimate for this assignment
+                const requestType = getColumnValue(row, requestsData.columnMap, CONFIG.columns.requests.type);
+                const realisticEstimates = {
+                  'Funeral': 0.5,
+                  'Wedding': 2.5,
+                  'VIP': 4.0,
+                  'Float Movement': 4.0,
+                  'Other': 2.0
+                };
+                requestHours += realisticEstimates[requestType] || realisticEstimates['Other'];
+              }
+            }
+          });
+        } catch (error) {
+          console.warn('Error calculating request hours from assignments:', error);
+          // Fallback to request type estimate
           const requestType = getColumnValue(row, requestsData.columnMap, CONFIG.columns.requests.type);
-          const typeEstimates = {
+          const realisticEstimates = {
+            'Funeral': 0.5,
             'Wedding': 2.5,
-            'Funeral': 1.5,
-            'Float Movement': 3.0,
-            'VIP': 2.0,
+            'VIP': 4.0,
+            'Float Movement': 4.0,
             'Other': 2.0
           };
-          totalHours += typeEstimates[requestType] || typeEstimates['Other'];
+          requestHours = realisticEstimates[requestType] || realisticEstimates['Other'];
         }
+        
+        totalHours += requestHours;
       }
     });
 

--- a/Config.gs
+++ b/Config.gs
@@ -103,6 +103,9 @@ const CONFIG = {
       smsSent: 'SMS Sent',
       emailSent: 'Email Sent',
       completedDate: 'Completed Date',
+      actualStartTime: 'Actual Start Time',
+      actualEndTime: 'Actual End Time',
+      actualDuration: 'Actual Duration (Hours)',
       calendarEventId: 'Calendar Event ID',
       notes: 'Notes'
     },

--- a/REPORTS_FIX_SUMMARY.md
+++ b/REPORTS_FIX_SUMMARY.md
@@ -1,0 +1,136 @@
+# Reports Page Zero Hours Issue - FIX APPLIED ✅
+
+## Issue Summary
+The reports page was showing 0 hours for all riders and 0 total escort hours, even though riders had completed assigned escorts.
+
+## Root Cause Identified
+The problem was in the `generateReportData()` function in `Code.gs`. The calculation logic was:
+
+1. **Too restrictive status filtering**: Only counting assignments with status = 'Completed'
+2. **Missing time data handling**: Not handling cases where startTime/endTime were empty or invalid
+3. **Strict rider name matching**: Exact string comparison without trimming/case handling
+
+## Fixes Applied
+
+### 1. Enhanced Status Matching
+**Before**: Only counted status = 'Completed'
+```javascript
+if (assignmentRider === riderName && status === 'Completed' && dateMatches)
+```
+
+**After**: Counts multiple relevant statuses
+```javascript
+const statusLower = (status || '').toLowerCase().trim();
+const countableStatuses = ['completed', 'in progress', 'assigned', 'confirmed', 'en route'];
+if (countableStatuses.includes(statusLower))
+```
+
+### 2. Improved Rider Name Matching
+**Before**: Exact string match
+```javascript
+if (assignmentRider === riderName)
+```
+
+**After**: Case-insensitive with trimming
+```javascript
+if (assignmentRider && riderName && 
+    assignmentRider.toString().trim().toLowerCase() === riderName.toString().trim().toLowerCase())
+```
+
+### 3. Fallback Hour Estimation
+**Before**: If no valid times, no hours counted
+```javascript
+if (start && end && end > start) {
+  totalHours += (end.getTime() - start.getTime()) / (1000 * 60 * 60);
+}
+```
+
+**After**: Estimates hours by request type when times missing
+```javascript
+if (start && end && end > start) {
+  totalHours += (end.getTime() - start.getTime()) / (1000 * 60 * 60);
+} else {
+  const estimatedHours = estimateEscortHoursByType(assignment, assignmentsData.columnMap);
+  totalHours += estimatedHours;
+}
+```
+
+### 4. Hour Estimation by Request Type
+Added intelligent hour estimation based on escort type:
+- **Wedding**: 2.5 hours
+- **Funeral**: 1.5 hours  
+- **Float Movement**: 3.0 hours
+- **VIP**: 2.0 hours
+- **Other**: 2.0 hours (default)
+
+## New Functions Added
+
+### `estimateEscortHoursByType(assignment, columnMap)`
+- Estimates hours when actual time data is missing
+- Uses request type to provide realistic hour estimates
+- Falls back to 2.0 hours default
+
+### `debugAssignmentDataForReports()`
+- Diagnostic function to analyze assignment data
+- Shows status distribution, rider counts, time data availability
+- Helps troubleshoot future issues
+
+### `testReportsFixForZeroHours()`
+- Test function to verify the fix is working
+- Can be run manually to check escort hour calculations
+- Provides detailed test results
+
+## Files Modified
+- **Code.gs**: Updated `generateReportData()`, `generateRiderActivityReport()`, and `generateExecutiveSummary()` functions
+- **reports_analysis_and_fix.md**: Detailed technical analysis document
+- **REPORTS_FIX_SUMMARY.md**: This summary document
+
+## Testing the Fix
+
+### Option 1: Use the Test Function
+In Google Apps Script editor:
+1. Open `Code.gs`
+2. Find and run the function `testReportsFixForZeroHours()`
+3. Check the console output for results
+
+### Option 2: Use the Debug Function
+Run `debugAssignmentDataForReports()` to see:
+- Total assignments and riders
+- Status distribution
+- Sample assignment data
+- Time data availability
+
+### Option 3: Check Reports Page
+1. Go to the reports page in the web app
+2. Select a date range (last 30 days recommended)
+3. Generate reports
+4. Check if rider hours now show non-zero values
+
+## Expected Results After Fix
+
+✅ **Riders should now show escort counts > 0**
+✅ **Hours should be calculated and displayed (estimated if needed)**
+✅ **Reports page should show meaningful data**
+✅ **Executive summary should show total hours**
+
+## If Issues Persist
+
+1. **Run the debug function** to check data availability
+2. **Check assignment statuses** - they should include: Assigned, Confirmed, In Progress, Completed
+3. **Verify rider names match** between Riders and Assignments sheets
+4. **Check date ranges** - make sure assignments exist in the selected period
+
+## Long-term Recommendations
+
+1. **Implement actual time tracking**: Add check-in/check-out functionality for riders
+2. **Standardize assignment statuses**: Ensure consistent status values across the system
+3. **Add time validation**: Validate that escort times are reasonable (e.g., 0.5-8 hours)
+4. **Enhanced mobile app**: Allow riders to log actual start/end times
+
+## Contact for Support
+If the fix doesn't resolve the issue, run the debug function and provide the output for further analysis.
+
+---
+**Fix Applied**: ✅ Ready for testing
+**Compatibility**: Should work with existing data structure
+**Risk Level**: Low (mainly expands what gets counted, doesn't remove functionality)

--- a/reports_analysis_and_fix.md
+++ b/reports_analysis_and_fix.md
@@ -1,0 +1,247 @@
+# Reports Page - Zero Hours Issue Analysis and Fix
+
+## Problem Summary
+The reports page shows 0 hours for all riders and 0 total escort hours, even though riders have completed assigned escorts. This issue affects the "Rider Activity" section and overall reporting accuracy.
+
+## Root Cause Analysis
+
+### 1. **Data Flow Issue in Rider Hours Calculation**
+The problem lies in the `generateReportData()` function in `Code.gs` (lines 2750-2780). The calculation logic is:
+
+```javascript
+// Current problematic logic
+assignmentsData.data.forEach(assignment => {
+  const assignmentRider = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.riderName);
+  const status = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.status);
+  const eventDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate);
+
+  if (assignmentRider === riderName && status === 'Completed' && dateMatches) {
+    escorts++;
+    const start = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime));
+    const end = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime));
+    if (start && end && end > start) {
+      totalHours += (end.getTime() - start.getTime()) / (1000 * 60 * 60);
+    }
+  }
+});
+```
+
+### 2. **Potential Issues Identified**
+
+#### A. **Assignment Status Issue**
+- The code only counts assignments with status = 'Completed'
+- If assignments are marked as 'Assigned', 'In Progress', or other statuses, they won't be counted
+- Status values might be inconsistent (case sensitivity, extra spaces)
+
+#### B. **Time Data Issues**
+- `startTime` and `endTime` in assignments may be empty/null
+- These fields might contain the original request times, not actual escort times
+- Time parsing might fail due to format inconsistencies
+- No actual escort completion times are being tracked
+
+#### C. **Date Filtering Issues**
+- Date comparison logic might exclude valid assignments
+- Date parsing issues could cause assignments to be filtered out
+
+#### D. **Data Structure Issues**
+- Column mappings might not match actual sheet structure
+- Missing or misnamed columns in assignments sheet
+
+## Diagnostic Steps
+
+### Step 1: Check Assignment Data
+```javascript
+// Add this debug function to diagnose the issue
+function debugAssignmentData() {
+  const assignmentsData = getAssignmentsData();
+  console.log('Total assignments found:', assignmentsData.data.length);
+  
+  // Check first 5 assignments
+  for (let i = 0; i < Math.min(5, assignmentsData.data.length); i++) {
+    const assignment = assignmentsData.data[i];
+    console.log(`Assignment ${i}:`, {
+      riderName: getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.riderName),
+      status: getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.status),
+      eventDate: getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate),
+      startTime: getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime),
+      endTime: getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime)
+    });
+  }
+  
+  // Check status distribution
+  const statusCounts = {};
+  assignmentsData.data.forEach(assignment => {
+    const status = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.status);
+    statusCounts[status] = (statusCounts[status] || 0) + 1;
+  });
+  console.log('Status distribution:', statusCounts);
+}
+```
+
+## Immediate Fix Solutions
+
+### Solution 1: Enhanced Hours Calculation (Recommended)
+
+Replace the current rider hours calculation logic with this improved version:
+
+```javascript
+// Enhanced rider hours calculation
+function calculateRiderHoursImproved(startDate, endDate) {
+  const assignmentsData = getAssignmentsData();
+  const ridersData = getRidersData();
+  const riderHours = [];
+  
+  ridersData.data.forEach(rider => {
+    const riderName = getColumnValue(rider, ridersData.columnMap, CONFIG.columns.riders.name);
+    if (!riderName) return;
+
+    let totalHours = 0;
+    let escorts = 0;
+
+    assignmentsData.data.forEach(assignment => {
+      const assignmentRider = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.riderName);
+      const status = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.status);
+      const eventDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate);
+
+      // More flexible rider name matching
+      if (!assignmentRider || !riderName) return;
+      if (assignmentRider.trim().toLowerCase() !== riderName.trim().toLowerCase()) return;
+
+      // Date filtering
+      let dateMatches = true;
+      if (eventDate && startDate && endDate) {
+        const assignmentDate = eventDate instanceof Date ? eventDate : new Date(eventDate);
+        if (!isNaN(assignmentDate.getTime())) {
+          dateMatches = assignmentDate >= startDate && assignmentDate <= endDate;
+        }
+      }
+      if (!dateMatches) return;
+
+      // More flexible status matching - count any assignment that was worked
+      const statusLower = (status || '').toLowerCase().trim();
+      const validStatuses = ['completed', 'in progress', 'assigned', 'confirmed', 'en route'];
+      
+      if (validStatuses.includes(statusLower)) {
+        escorts++;
+        
+        // Try to calculate hours from time data
+        const start = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime));
+        const end = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime));
+        
+        if (start && end && end > start) {
+          const hours = (end.getTime() - start.getTime()) / (1000 * 60 * 60);
+          totalHours += hours;
+        } else {
+          // Fallback: estimate hours based on request type or default
+          const estimatedHours = estimateEscortHours(assignment, assignmentsData.columnMap);
+          totalHours += estimatedHours;
+        }
+      }
+    });
+
+    riderHours.push({
+      name: riderName,
+      escorts: escorts,
+      hours: Math.round(totalHours * 100) / 100
+    });
+  });
+
+  return riderHours.sort((a, b) => b.hours - a.hours);
+}
+
+// Helper function to estimate hours when actual times aren't available
+function estimateEscortHours(assignment, columnMap) {
+  // Get request details to estimate duration
+  const requestId = getColumnValue(assignment, columnMap, CONFIG.columns.assignments.requestId);
+  
+  // Default estimates by request type (in hours)
+  const typeEstimates = {
+    'Wedding': 2.5,
+    'Funeral': 1.5,
+    'Float Movement': 3.0,
+    'VIP': 2.0,
+    'Other': 2.0
+  };
+  
+  // Try to get the request type from the original request
+  try {
+    const requestsData = getRequestsData();
+    const request = requestsData.data.find(r => 
+      getColumnValue(r, requestsData.columnMap, CONFIG.columns.requests.id) === requestId
+    );
+    
+    if (request) {
+      const requestType = getColumnValue(request, requestsData.columnMap, CONFIG.columns.requests.type);
+      return typeEstimates[requestType] || typeEstimates['Other'];
+    }
+  } catch (error) {
+    console.warn('Could not estimate hours from request data:', error);
+  }
+  
+  return typeEstimates['Other']; // Default fallback
+}
+```
+
+### Solution 2: Fix the Current Implementation
+
+Update the existing `generateReportData` function:
+
+```javascript
+// Fix in generateReportData function around line 2750
+if (assignmentRider === riderName && dateMatches) {
+  // More flexible status checking
+  const statusLower = (status || '').toLowerCase().trim();
+  const countableStatuses = ['completed', 'in progress', 'assigned', 'confirmed'];
+  
+  if (countableStatuses.includes(statusLower)) {
+    escorts++;
+    
+    const start = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.startTime));
+    const end = parseTimeString(getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.endTime));
+    
+    if (start && end && end > start) {
+      totalHours += (end.getTime() - start.getTime()) / (1000 * 60 * 60);
+    } else {
+      // Add estimated hours for assignments without time data
+      totalHours += 2.0; // Default 2 hours per escort
+    }
+  }
+}
+```
+
+## Long-term Improvements
+
+### 1. Add Actual Escort Completion Tracking
+Add new columns to the Assignments sheet:
+- `Actual Start Time`
+- `Actual End Time` 
+- `Escort Duration (Hours)`
+
+### 2. Enhanced Assignment Status Workflow
+Implement proper status transitions:
+- `Assigned` → `Confirmed` → `En Route` → `In Progress` → `Completed`
+
+### 3. Mobile App Integration
+Allow riders to check in/out via mobile app to track actual escort times.
+
+### 4. Improved Reporting
+- Real-time hours tracking
+- Weekly/monthly summaries
+- Performance metrics per rider
+
+## Testing the Fix
+
+After implementing the fix:
+
+1. Run the debug function to check data
+2. Test reports with different date ranges
+3. Verify escort counts match expectations
+4. Check that hours are calculated for all active riders
+
+## Files to Modify
+
+1. **Code.gs** - Update `generateReportData()` function (lines ~2750-2780)
+2. **Code.gs** - Add debug function for troubleshooting
+3. **Consider updating assignments workflow** to better track completion
+
+The fix should immediately resolve the zero hours issue by using more flexible status matching and providing fallback hour estimates when actual times aren't available.


### PR DESCRIPTION
Prioritize actual completion times for escort hour calculations on reports.

This PR fixes the reports page showing 0 hours for completed escorts by:
1. Prioritizing "Actual Duration (Hours)" or "Actual Start/End Time" from new columns.
2. Using refined estimates (0.5-4.0 hours) only for past events where actual data is missing.
3. Introducing `setupActualCompletionTimeColumns()` to add necessary columns for tracking.