### PR TITLE
Fix duplicate function name for dashboard data

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -144,7 +144,7 @@ function getEscortDetailsForAssignment(requestIdInput) {
 /**
  * Enhanced getPageData with access control
  */
-function getPageDataForDashboard(user) {
+function getSecuredDashboardPageData(user) {
   try {
     // Validate user authentication
     if (!user || !user.role) {
@@ -566,7 +566,7 @@ function getSecuredPageData(pageName, user, filters = {}) {
   try {
     // Map page names to secured functions
     const pageHandlers = {
-      'dashboard': () => getPageDataForDashboard(user),
+      'dashboard': () => getSecuredDashboardPageData(user),
       'requests': () => getPageDataForRequests(user, filters),
       'assignments': () => getPageDataForAssignments(user, filters),
       'riders': () => getPageDataForRiders(user, filters),


### PR DESCRIPTION
## Summary
- rename secure `getPageDataForDashboard` to `getSecuredDashboardPageData`
- update usage in secured page handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686545f367688323a77286b429f145f4