### PR TITLE
Fix mobile script injection

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -6438,8 +6438,16 @@ function addMobileOptimizations(htmlOutput, user, rider) {
 })();
 </script>`;
     
-const currentContent = htmlOutput.getContent();
-htmlOutput.setContent(currentContent + mobileScript);
+    const currentContent = htmlOutput.getContent();
+    let newContent;
+    if (currentContent.includes('</body>')) {
+      newContent = currentContent.replace('</body>', mobileScript + '</body>');
+    } else if (currentContent.includes('</html>')) {
+      newContent = currentContent.replace('</html>', mobileScript + '</html>');
+    } else {
+      newContent = currentContent + mobileScript;
+    }
+    htmlOutput.setContent(newContent);
     return htmlOutput;
     
   } catch (error) {


### PR DESCRIPTION
## Summary
- inject mobile optimization script before closing `</body>`/`</html>` tags to avoid stray text on dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68654b9e6b4c8323b5342c5d8384c014