### PR TITLE
Add link to rider availability calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,17 @@
 
     <div class="container">
         <!--NAVIGATION_MENU_PLACEHOLDER-->
+        
+        <!-- Fallback Navigation - shown if server-side replacement fails -->
+        <nav class="navigation" id="fallback-navigation" style="display: none;">
+            <a href="index.html" class="nav-button active" data-page="dashboard">📊 Dashboard</a>
+            <a href="requests.html" class="nav-button" data-page="requests">📋 Requests</a>
+            <a href="assignments.html" class="nav-button" data-page="assignments">🏍️ Assignments</a>
+            <a href="riders.html" class="nav-button" data-page="riders">👥 Riders</a>
+            <a href="rider-availability.html" class="nav-button" data-page="availability">🗓️ Availability</a>
+            <a href="notifications.html" class="nav-button" data-page="notifications">📱 Notifications</a>
+            <a href="reports.html" class="nav-button" data-page="reports">📊 Reports</a>
+        </nav>
 
         <div class="dashboard-grid">
             <!-- Statistics Card -->
@@ -408,6 +419,9 @@
                     <button class="action-button" onclick="openAssignments()" id="assignRidersBtn">
                         🏍️ Assign Riders
                     </button>
+                    <button class="action-button" onclick="openRiderAvailability()">
+                        🗓️ Rider Availability
+                    </button>
                     <button class="action-button" onclick="sendBulkNotifications()" id="notificationsBtn">
                         📱 Send Notifications
                     </button>
@@ -438,6 +452,11 @@
     document.addEventListener('DOMContentLoaded', () => {
         console.log('🚀 Dashboard loading...');
 
+        // Check if navigation was properly loaded and show fallback if needed
+        setTimeout(() => {
+            checkAndShowNavigation();
+        }, 500);
+
         // Retrieve the web app URL when running inside Apps Script
         if (typeof google !== 'undefined' && google.script && google.script.run) {
             try {
@@ -459,6 +478,39 @@
 
         initializeDashboard();
     });
+
+    function checkAndShowNavigation() {
+        // Check if the navigation placeholder still exists (wasn't replaced by server)
+        const hasPlaceholder = document.documentElement.innerHTML.includes('<!--NAVIGATION_MENU_PLACEHOLDER-->');
+        
+        // Check if there's already a visible navigation
+        const existingNav = document.querySelector('.navigation:not(#fallback-navigation)');
+        const hasVisibleNav = existingNav && existingNav.offsetParent !== null;
+        
+        console.log('🧭 Navigation check - Placeholder exists:', hasPlaceholder, 'Visible nav exists:', hasVisibleNav);
+        
+        // If placeholder wasn't replaced or no visible navigation, show fallback
+        if (hasPlaceholder || !hasVisibleNav) {
+            const fallbackNav = document.getElementById('fallback-navigation');
+            if (fallbackNav) {
+                fallbackNav.style.display = 'flex';
+                console.log('✅ Fallback navigation displayed');
+                
+                // Add click handlers to fallback navigation links
+                fallbackNav.querySelectorAll('a').forEach(link => {
+                    link.addEventListener('click', function(e) {
+                        e.preventDefault();
+                        const page = this.getAttribute('data-page');
+                        if (page === 'dashboard') {
+                            window.location.href = 'index.html';
+                        } else {
+                            window.location.href = this.getAttribute('href');
+                        }
+                    });
+                });
+            }
+        }
+    }
 
     function initializeDashboard() {
         console.log('🔄 Initializing dashboard with consolidated data call...');
@@ -771,6 +823,10 @@
 
     function openAssignments() {
         navigateTo('assignments');
+    }
+
+    function openRiderAvailability() {
+        window.location.href = 'rider-availability.html';
     }
 
     function goToRiders(status) {


### PR DESCRIPTION
Add direct links and a robust fallback for the rider availability calendar to the dashboard.

The existing navigation placeholder was not reliably replaced by the server-side script, making the 'Availability' link inaccessible. This PR adds a direct quick action button and a client-side fallback navigation to ensure consistent access to the rider availability page.