### PR TITLE
Fix view button for rider assignments

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -1838,9 +1838,9 @@ function createAssignmentRow(assignment, isPast = false) {
   const statusClass = status.toLowerCase().replace(' ', '-');
   const actionButtons = isPast ? '' : `
     <td class="assignment-actions">
-      <a class="btn btn-sm btn-info" title="View Request Details"
+      <a class="btn btn-sm btn-info" title="View Assignment Details"
          href="#"
-         onclick="viewRequestDetails('${requestId}'); return false;">
+         onclick="openAssignment('${requestId}'); return false;">
         👁️ View
       </a>
     </td>


### PR DESCRIPTION
## Summary
- update rider assignment modal to open the assignments page for the selected request

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf00f5388323ac90ecb1e227c3e6