### PR TITLE
Add platoon column to rider management

### DIFF
--- a/Config.gs
+++ b/Config.gs
@@ -83,7 +83,8 @@ const CONFIG = {
       phone: 'Phone Number',
       email: 'Email',
       status: 'Status',
-      partTime: 'Part-Time Rider',  
+      platoon: 'Platoon',
+      partTime: 'Part-Time Rider',
       certification: 'Certification',
       totalAssignments: 'Total Assignments',
       lastAssignmentDate: 'Last Assignment Date'  // Fixed: was 'LastAssignmentDate'
@@ -135,6 +136,7 @@ const CONFIG = {
     requestTypes: ['Wedding', 'Funeral', 'Float Movement', 'VIP', 'Other'],
     requestStatuses: ['New', 'Pending', 'Assigned', 'Unassigned', 'In Progress', 'Completed', 'Cancelled'],
     riderStatuses: ['Active', 'Inactive', 'Vacation', 'Training', 'Suspended'],
+    platoons: ['A', 'B'],
     certificationTypes: ['Standard', 'Advanced', 'Instructor', 'Trainee', 'Not Certified'],
     assignmentStatuses: ['Assigned', 'Confirmed', 'En Route', 'In Progress', 'Completed', 'Cancelled', 'No Show']
   },

--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -321,12 +321,14 @@ function addRider(riderData) {
     });
 
     // Support common variations of the part time field
-    const normalizedPartTime =
+   const normalizedPartTime =
       normalizedData['part time'] ||
       normalizedData['part-time'] ||
       normalizedData['parttimerider'] ||
       normalizedData['part time rider'] ||
       normalizedData['parttime'];
+
+    const normalizedPlatoon = normalizedData['platoon'];
 
     // Create new row array based on headers
     const newRowArray = headers.map(header => {
@@ -346,6 +348,8 @@ function addRider(riderData) {
           return '';
         case CONFIG.columns.riders.partTime:
           return normalizedPartTime || 'No';
+        case CONFIG.columns.riders.platoon:
+          return normalizedPlatoon || '';
         case CONFIG.columns.riders.certification:
           return riderData[header] || 'Standard';
         default:
@@ -592,6 +596,7 @@ function mapRowToRiderObject(row, columnMap, headers) {
   rider.phone = getColumnValue(row, columnMap, CONFIG.columns.riders.phone) || '';
   rider.email = getColumnValue(row, columnMap, CONFIG.columns.riders.email) || '';
   rider.status = getColumnValue(row, columnMap, CONFIG.columns.riders.status) || 'Active';
+  rider.platoon = getColumnValue(row, columnMap, CONFIG.columns.riders.platoon) || '';
   let partTimeVal = getColumnValue(row, columnMap, CONFIG.columns.riders.partTime);
   if (partTimeVal === null || partTimeVal === '') {
     partTimeVal = getColumnValue(row, columnMap, 'Part Time Rider');
@@ -1120,6 +1125,14 @@ function validateRiderData(riderData, isUpdate = false) {
       const validStatuses = CONFIG.options?.riderStatuses || ['Active', 'Inactive', 'Vacation', 'Training', 'Suspended'];
       if (!validStatuses.includes(riderData[CONFIG.columns.riders.status])) {
         errors.push(`Status must be one of: ${validStatuses.join(', ')}`);
+      }
+    }
+
+    if (riderData[CONFIG.columns.riders.platoon]) {
+      const platoon = String(riderData[CONFIG.columns.riders.platoon]).trim();
+      const validPlatoons = CONFIG.options?.platoons || ['A', 'B'];
+      if (platoon && !validPlatoons.includes(platoon)) {
+        errors.push('Platoon must be A or B');
       }
     }
     

--- a/riders.html
+++ b/riders.html
@@ -591,6 +591,7 @@
                             <th>Phone</th>
                             <th>Email</th>
                             <th>Status</th>
+                            <th>Platoon</th>
                             <th>Part Time</th>
                             <th>Certification</th>
                             <th>Assignments</th>
@@ -650,6 +651,15 @@
                                 <option value="Vacation">On Vacation</option>
                                 <option value="Training">In Training</option>
                                 <option value="Suspended">Suspended</option>
+                            </select>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="riderPlatoon">Platoon</label>
+                            <select id="riderPlatoon" name="riderPlatoon">
+                                <option value=""></option>
+                                <option value="A">A</option>
+                                <option value="B">B</option>
                             </select>
                         </div>
 
@@ -1071,6 +1081,7 @@ function editRider(riderId) {
   document.getElementById('riderPhone').value = rider.phone || rider['Phone Number'] || '';
   document.getElementById('riderEmail').value = rider.email || rider['Email'] || '';
   document.getElementById('riderStatus').value = rider.status || rider['Status'] || 'Active';
+  document.getElementById('riderPlatoon').value = rider.platoon || rider['Platoon'] || '';
   document.getElementById('riderPartTime').value = rider.partTime || rider['Part Time'] || 'No';
   document.getElementById('riderCertification').value = rider.certification || rider['Certification'] || 'Standard';
 
@@ -1190,6 +1201,7 @@ function saveRider() {
     'Phone Number': formData.get('riderPhone'),
     'Email': formData.get('riderEmail'),
     'Status': formData.get('riderStatus'),
+    'Platoon': formData.get('riderPlatoon'),
     'Part Time': formData.get('riderPartTime'),
     'Certification': formData.get('riderCertification') // ← Check this value
   };
@@ -1536,6 +1548,7 @@ function renderRidersTable(riders) {
     const riderPhone = rider.phone || rider['Phone Number'] || '';
     const riderEmail = rider.email || rider['Email'] || '';
     const riderStatus = rider.status || rider['Status'] || 'Active';
+    const riderPlatoon = rider.platoon || rider['Platoon'] || '';
     const riderPartTime = rider.partTime || rider['Part Time'] || 'No';
     const riderCertification = rider.certification || rider['Certification'] || 'Standard';
     const totalAssignments = rider.totalAssignments || rider['Total Assignments'] || 0;
@@ -1555,6 +1568,7 @@ function renderRidersTable(riders) {
       <td class="rider-phone-cell">${riderPhone}</td>
       <td>${riderEmail}</td>
       <td><span class="status-badge status-${riderStatus.toLowerCase()}">${riderStatus}</span></td>
+      <td>${riderPlatoon}</td>
       <td>${riderPartTime}</td>
       <td>${riderCertification}</td>
       <td id="assign-count-${riderId}">${totalAssignments}</td>


### PR DESCRIPTION
## Summary
- support new `Platoon` column in configuration
- include platoon when creating or updating riders
- validate platoon field
- display platoon on riders page and allow editing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf0ee8a48323844ce6e57d3ac99a