### PR TITLE
Add Escort Fee field

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -105,6 +105,7 @@ function getEscortDetailsForAssignment(requestIdInput) {
     const requestDetails = {
       id: getColumnValue(foundRequestRow, requestColMap, CONFIG.columns.requests.id),
       ridersNeeded: getColumnValue(foundRequestRow, requestColMap, CONFIG.columns.requests.ridersNeeded),
+      escortFee: getColumnValue(foundRequestRow, requestColMap, CONFIG.columns.requests.escortFee),
       eventDate: getColumnValue(foundRequestRow, requestColMap, CONFIG.columns.requests.eventDate),
       startTime: getColumnValue(foundRequestRow, requestColMap, CONFIG.columns.requests.startTime),
       endTime: getColumnValue(foundRequestRow, requestColMap, CONFIG.columns.requests.endTime),
@@ -2398,6 +2399,7 @@ function getFilteredRequestsForWebApp(user, filter = 'All', rawRequestsInput = n
           endLocation: getColumnValue(row, columnMap, CONFIG.columns.requests.endLocation) || '',
           secondaryEndLocation: getColumnValue(row, columnMap, CONFIG.columns.requests.secondaryLocation) || '',
           ridersNeeded: getColumnValue(row, columnMap, CONFIG.columns.requests.ridersNeeded) || 1,
+          escortFee: getColumnValue(row, columnMap, CONFIG.columns.requests.escortFee) || '',
           status: status || 'New',
           specialRequirements: getColumnValue(row, columnMap, CONFIG.columns.requests.requirements) || '',
           notes: getColumnValue(row, columnMap, CONFIG.columns.requests.notes) || '',

--- a/Config.gs
+++ b/Config.gs
@@ -69,6 +69,7 @@ const CONFIG = {
       endLocation: 'End Location',
       secondaryLocation: 'Secondary End Location',
       ridersNeeded: 'Riders Needed',
+      escortFee: 'Escort Fee',
       requirements: 'Special Requirements',
       status: 'Status',
       notes: 'Notes',

--- a/RequestCRUD.gs
+++ b/RequestCRUD.gs
@@ -85,6 +85,9 @@ function createNewRequest(requestData, submittedBy = Session.getActiveUser().get
             case CONFIG.columns.requests.secondaryLocation:   value = requestData.secondaryLocation || ''; break;
             case CONFIG.columns.requests.type:                value = requestData.requestType; break; // Ensure 'type' matches CONFIG
             case CONFIG.columns.requests.ridersNeeded:        value = parseInt(requestData.ridersNeeded); break;
+            case CONFIG.columns.requests.escortFee:
+                value = requestData.escortFee ? parseFloat(requestData.escortFee) : '';
+                break;
             case CONFIG.columns.requests.status:
                 value = (CONFIG.options && CONFIG.options.requestStatuses && CONFIG.options.requestStatuses.length > 0)
                     ? CONFIG.options.requestStatuses[0]
@@ -429,6 +432,7 @@ function updateExistingRequest(requestData) {
       endLocation: CONFIG.columns.requests.endLocation,
       secondaryEndLocation: CONFIG.columns.requests.secondaryLocation,
       ridersNeeded: CONFIG.columns.requests.ridersNeeded,
+      escortFee: CONFIG.columns.requests.escortFee,
       status: CONFIG.columns.requests.status,
       courtesy: CONFIG.columns.requests.courtesy,
       specialRequirements: CONFIG.columns.requests.requirements,
@@ -479,6 +483,13 @@ function updateExistingRequest(requestData) {
               if (isNaN(value) || value <= 0) {
                 throw new Error(`Invalid number of riders needed: ${requestData[formField]}`);
               }
+            }
+            break;
+
+          case CONFIG.columns.requests.escortFee:
+            if (value !== undefined && value !== null && value !== '') {
+              value = parseFloat(value);
+              if (isNaN(value)) value = '';
             }
             break;
             

--- a/requests.html
+++ b/requests.html
@@ -593,6 +593,7 @@
                         <th>Start Location</th>
                         <th>End Location</th>
                         <th>Riders Needed</th>
+                        <th>Escort Fee</th>
                         <th>Status</th>
                         <th>Assigned</th>
                         <th>Notes</th>
@@ -679,6 +680,11 @@
                             <div class="form-group">
                                 <label for="editRidersNeeded">Riders Needed *</label>
                                 <input type="number" id="editRidersNeeded" min="1" max="10" required />
+                            </div>
+
+                            <div class="form-group">
+                                <label for="editEscortFee">Escort Fee</label>
+                                <input type="number" id="editEscortFee" min="0" max="9999" step="0.01" style="width:6rem;" />
                             </div>
                             
                             <div class="form-group">
@@ -830,6 +836,7 @@
      * @property {string} endLocation
      * @property {string} [secondaryEndLocation]
      * @property {number} ridersNeeded
+     * @property {string} [escortFee]
      * @property {string} status
      * @property {string} [courtesy] - 'Yes' or 'No'
      * @property {string} [specialRequirements]
@@ -1068,6 +1075,7 @@
                 <td>${request.startLocation || ''}</td>
                 <td>${request.endLocation || ''}</td>
                 <td style="text-align: center;">${request.ridersNeeded || 0}</td>
+                <td style="text-align: center;">${request.escortFee || ''}</td>
                 <td><span class="status-badge ${statusClass}">${request.status || 'New'}</span></td>
                 <td>${assigned}</td>
                 <td><span class="notes" title="${request.notes || ''}">${request.notes || ''}</span></td>
@@ -1199,6 +1207,7 @@
         document.getElementById('editEndLocation').value = request.endLocation || '';
         document.getElementById('editSecondaryLocation').value = request.secondaryEndLocation || '';
         document.getElementById('editRidersNeeded').value = request.ridersNeeded || 1;
+        document.getElementById('editEscortFee').value = request.escortFee || '';
         document.getElementById('editStatus').value = request.status || 'New';
         document.getElementById('editCourtesy').checked = (request.courtesy === 'Yes' || String(request.courtesy).toLowerCase() === 'true');
         document.getElementById('editSpecialRequirements').value = request.specialRequirements || '';
@@ -1224,6 +1233,7 @@
 
         document.getElementById('editStatus').value = 'New';
         document.getElementById('editRidersNeeded').value = 1;
+        document.getElementById('editEscortFee').value = '';
 
         document.getElementById('modalTitle').textContent = 'Add New Request';
         document.getElementById('deleteBtn').style.display = 'none';
@@ -1285,6 +1295,7 @@
             endLocation: document.getElementById('editEndLocation').value.trim(),
             secondaryEndLocation: document.getElementById('editSecondaryLocation').value.trim(),
             ridersNeeded: parseInt(document.getElementById('editRidersNeeded').value),
+            escortFee: document.getElementById('editEscortFee').value,
             status: document.getElementById('editStatus').value,
             courtesy: document.getElementById('editCourtesy').checked ? 'Yes' : 'No',
             specialRequirements: document.getElementById('editSpecialRequirements').value.trim(),
@@ -1352,6 +1363,7 @@
             endLocation: document.getElementById('editEndLocation').value.trim(),
             secondaryEndLocation: document.getElementById('editSecondaryLocation').value.trim(),
             ridersNeeded: parseInt(document.getElementById('editRidersNeeded').value),
+            escortFee: document.getElementById('editEscortFee').value,
             status: 'Completed',
             courtesy: document.getElementById('editCourtesy').checked ? 'Yes' : 'No',
             specialRequirements: document.getElementById('editSpecialRequirements').value.trim(),
@@ -1576,7 +1588,7 @@
         }
 
         const headers = ['Request ID', 'Event Date', 'Start Time', 'End Time', 'Requester', 'Type',
-                       'Start Location', 'End Location', 'Riders Needed', 'Status', 'Assigned', 'Notes'];
+                       'Start Location', 'End Location', 'Riders Needed', 'Escort Fee', 'Status', 'Assigned', 'Notes'];
 
         const csvRows = [headers.join(',')];
 
@@ -1591,6 +1603,7 @@
                 req.startLocation || '',
                 req.endLocation || '',
                 req.ridersNeeded || '',
+                req.escortFee || '',
                 req.status || '',
                 req.ridersAssigned || '',
                 `"${(req.notes || '').replace(/"/g, '""')}"` // Escape double quotes in notes


### PR DESCRIPTION
## Summary
- add `Escort Fee` column in config
- capture escort fee when creating or updating requests
- expose fee field through AppServices and in request table
- update requests UI with Escort Fee input, display, and CSV export

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866f7bbf87883238560ceec5c87fe08