### PR TITLE
Add rider availability calendar link

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -3,6 +3,7 @@
     <a href="requests.html" class="nav-button" id="nav-requests" data-page="requests" target="_top">📋 Requests</a>
     <a href="assignments.html" class="nav-button" id="nav-assignments" data-page="assignments" target="_top">🏍️ Assignments</a>
     <a href="riders.html" class="nav-button" id="nav-riders" data-page="riders" target="_top">👥 Riders</a>
+    <a href="enhanced-rider-availability.html" class="nav-button" id="nav-availability" data-page="availability" target="_top">🗓️ Availability</a>
     <a href="notifications.html" class="nav-button" id="nav-notifications" data-page="notifications" target="_top">📱 Notifications</a>
     <a href="reports.html" class="nav-button" id="nav-reports" data-page="reports" target="_top">📊 Reports</a>
 </nav>

--- a/index.html
+++ b/index.html
@@ -408,6 +408,9 @@
                     <button class="action-button" onclick="openAssignments()" id="assignRidersBtn">
                         🏍️ Assign Riders
                     </button>
+                    <button class="action-button" onclick="openRiderAvailability()" id="availabilityBtn">
+                        🗓️ Rider Availability
+                    </button>
                     <button class="action-button" onclick="sendBulkNotifications()" id="notificationsBtn">
                         📱 Send Notifications
                     </button>
@@ -771,6 +774,10 @@
 
     function openAssignments() {
         navigateTo('assignments');
+    }
+
+    function openRiderAvailability() {
+        navigateTo('availability');
     }
 
     function goToRiders(status) {


### PR DESCRIPTION
## Summary
- link to enhanced availability calendar in the shared navigation
- add quick access button on dashboard
- provide helper function for calendar navigation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867ea7d4a008323800e2e859a971906