### PR TITLE
Implement session reset and access checks

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -1361,16 +1361,21 @@ function doGet(e) {
     else if (rider?.status === 'Active') userRole = 'rider';
     else return createUnauthorizedPage(userSession.email, userSession.name);
     
-    const user = {
+  const user = {
       name: userSession.name || rider?.name || 'User',
       email: userSession.email,
       role: userRole,
       avatar: (userSession.name || rider?.name || 'U').charAt(0).toUpperCase()
     };
     
-    // Page loading
-    let pageName = e.parameter?.page || 'dashboard';
-    let pageFile = pageName;
+  // Page loading
+  let pageName = e.parameter?.page || 'dashboard';
+  let pageFile = pageName;
+
+  const access = checkPageAccessSafe(pageName, user, rider);
+  if (!access.allowed) {
+    return createAccessDeniedPage(access.reason, user);
+  }
     
     if (userRole === 'admin' && pageName === 'dashboard') pageFile = 'admin-dashboard';
     else if (userRole === 'rider' && pageName === 'dashboard') pageFile = 'rider-dashboard';

--- a/Code.gs
+++ b/Code.gs
@@ -4229,7 +4229,13 @@ function doGet(e) {
       
       return handleUserManagementPage(e);
     }
-    
+
+    // General page access check
+    const access = checkPageAccessSafe(pageName, authenticatedUser, rider);
+    if (!access.allowed) {
+      return createAccessDeniedPage(access.reason, authenticatedUser);
+    }
+
     // Load page content (your existing logic)
     const fileName = getPageFileNameSafe(pageName, authenticatedUser.role);
     let htmlOutput = HtmlService.createHtmlOutputFromFile(fileName);

--- a/login.html
+++ b/login.html
@@ -22,12 +22,12 @@
 </div>
 <script>
   document.getElementById('loginBtn').addEventListener('click', function(){
-    const email=document.getElementById('email').value.trim();
-    const pw=document.getElementById('password').value;
-    google.script.run.withSuccessHandler(handle).loginWithCredentials(email,pw);
+    const email = document.getElementById('email').value.trim();
+    const pw = document.getElementById('password').value;
+    google.script.run.withSuccessHandler(handle).secureLoginWithCredentials(email, pw);
   });
   document.getElementById('googleBtn').addEventListener('click', function(){
-    google.script.run.withSuccessHandler(handle).loginWithGoogle();
+    google.script.run.withSuccessHandler(handle).secureLoginWithGoogle();
   });
   function handle(res){
     if(res && res.success){


### PR DESCRIPTION
## Summary
- allow administrators to invalidate all sessions
- block navigation to pages users are not allowed to access
- use secure login APIs on the login page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686afec3fedc8323bc3d885c74ed0290