### PR TITLE
Update request location labels

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -591,7 +591,7 @@
                         <th>Requester</th>
                         <th>Type</th>
                         <th>Start Location</th>
-                        <th>End Location</th>
+                        <th>Second Location</th>
                         <th>Riders Needed</th>
                         <th>Escort Fee</th>
                         <th>Status</th>
@@ -668,12 +668,12 @@
                             </div>
                             
                             <div class="form-group">
-                                <label for="editEndLocation">End Location *</label>
+                                <label for="editEndLocation">Second Location *</label>
                                 <input type="text" id="editEndLocation" required />
                             </div>
                             
                             <div class="form-group">
-                                <label for="editSecondaryLocation">Secondary End Location</label>
+                                <label for="editSecondaryLocation">Final Location</label>
                                 <input type="text" id="editSecondaryLocation" />
                             </div>
                             
@@ -759,7 +759,7 @@
                             <strong>Start Location:</strong> <span id="assignmentStartLocation"></span>
                         </div>
                         <div>
-                            <strong>End Location:</strong> <span id="assignmentEndLocation"></span>
+                            <strong>Second Location:</strong> <span id="assignmentEndLocation"></span>
                         </div>
                     </div>
                 </div>
@@ -1588,7 +1588,7 @@
         }
 
         const headers = ['Request ID', 'Event Date', 'Start Time', 'End Time', 'Requester', 'Type',
-                       'Start Location', 'End Location', 'Riders Needed', 'Escort Fee', 'Status', 'Assigned', 'Notes'];
+                       'Start Location', 'Second Location', 'Riders Needed', 'Escort Fee', 'Status', 'Assigned', 'Notes'];
 
         const csvRows = [headers.join(',')];
 


### PR DESCRIPTION
## Summary
- rename "End Location" column to "Second Location" on the requests page
- rename "Secondary End Location" input to "Final Location"

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d87b0cce08323a2aa83fe04fb7c9c