### PR TITLE
Add Email_Responses sheet setup function

### DIFF
--- a/EmailResponsesSetup.gs
+++ b/EmailResponsesSetup.gs
@@ -1,0 +1,13 @@
+/**
+ * Ensure the Email_Responses sheet exists with the correct headers.
+ * Run this once to create the sheet manually if needed.
+ */
+function setupEmailResponsesSheet() {
+  getOrCreateSheet('Email_Responses', [
+    'Timestamp',
+    'From Email',
+    'Rider Name',
+    'Message Body',
+    'Action'
+  ]);
+}

--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ Access the login form by opening the web app URL with `?action=login`.  Users wh
 are not signed in or authorized will automatically be redirected to this form.
 Their name and role appear in the top‑right corner of each page once signed in.
 
+
+## Email Responses Sheet
+
+Incoming rider email replies are stored in a sheet named `Email_Responses`. If this sheet does not yet exist in your spreadsheet, run the Apps Script function `setupEmailResponsesSheet()` once to create it. The sheet will be initialized with the columns:
+
+```
+Timestamp | From Email | Rider Name | Message Body | Action
+```
+
+After running the setup function, automated email processing will log each response to this sheet and append the raw message text to the rider's assignment notes.
+


### PR DESCRIPTION
## Summary
- create `setupEmailResponsesSheet` to manually create the sheet if it doesn't exist
- document how to run this setup function in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d880b0df08323b5acbe24ffa4b55d