### PR TITLE
Replace Second Location label on requests page

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -591,7 +591,7 @@
                         <th>Requester</th>
                         <th>Type</th>
                         <th>Start Location</th>
-                        <th>Second Location</th>
+                        <th>Final Location</th>
                         <th>Riders Needed</th>
                         <th>Escort Fee</th>
                         <th>Status</th>
@@ -668,7 +668,7 @@
                             </div>
                             
                             <div class="form-group">
-                                <label for="editEndLocation">Second Location</label>
+                                <label for="editEndLocation">Final Location</label>
                                 <input type="text" id="editEndLocation" />
                             </div>
 
@@ -759,7 +759,7 @@
                             <strong>Start Location:</strong> <span id="assignmentStartLocation"></span>
                         </div>
                         <div>
-                            <strong>Second Location:</strong> <span id="assignmentEndLocation"></span>
+                            <strong>Final Location:</strong> <span id="assignmentEndLocation"></span>
                         </div>
                     </div>
                 </div>
@@ -1588,7 +1588,7 @@
         }
 
         const headers = ['Request ID', 'Event Date', 'Start Time', 'End Time', 'Requester', 'Type',
-                   'Start Location', 'Second Location', 'Riders Needed', 'Escort Fee', 'Status', 'Assigned', 'Notes'];
+                   'Start Location', 'Final Location', 'Riders Needed', 'Escort Fee', 'Status', 'Assigned', 'Notes'];
 
         const csvRows = [headers.join(',')];
 


### PR DESCRIPTION
## Summary
- update labels and CSV header on `requests.html` so 'Final Location' is used instead of 'Second Location'

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e7aee597c83238f300c62c007af27