### PR TITLE
Fix request status not updating when riders assigned

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -3362,6 +3362,16 @@ function processAssignmentAndPopulate(requestId, selectedRiders, usePriority) {
 
     // Update the request with assigned rider names
     updateRequestWithAssignedRiders(requestId, assignedRiderNames);
+
+    // Ensure status reflects new assignments
+    if (typeof updateRequestStatusBasedOnRiders === 'function') {
+      try {
+        updateRequestStatusBasedOnRiders(requestId);
+      } catch (statusError) {
+        logError(`Failed to auto-update status for ${requestId}`, statusError);
+      }
+    }
+
     if (usePriority !== false) {
       updateAssignmentRotation(assignedRiderNames);
     }


### PR DESCRIPTION
## Summary
- ensure status auto-updates when assignments are saved

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68712808831483239f82517ddbdb0d0d