### PR TITLE
Fix escort status not updating to assigned

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -3363,15 +3363,6 @@ function processAssignmentAndPopulate(requestId, selectedRiders, usePriority) {
     // Update the request with assigned rider names
     updateRequestWithAssignedRiders(requestId, assignedRiderNames);
 
-    // Ensure status reflects new assignments
-    if (typeof updateRequestStatusBasedOnRiders === 'function') {
-      try {
-        updateRequestStatusBasedOnRiders(requestId);
-      } catch (statusError) {
-        logError(`Failed to auto-update status for ${requestId}`, statusError);
-      }
-    }
-
     if (usePriority !== false) {
       updateAssignmentRotation(assignedRiderNames);
     }


### PR DESCRIPTION
Remove redundant status update call to fix escort status not changing to "assigned".

The `processAssignmentAndPopulate` function was calling `updateRequestStatusBasedOnRiders` immediately after `updateRequestWithAssignedRiders`. This caused a conflict where `updateRequestStatusBasedOnRiders` would read stale data and overwrite the correct 'assigned' status set by the first function, preventing the escort status from updating correctly.