### PR TITLE
Populate calendar with assigned riders

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -3367,6 +3367,15 @@ function processAssignmentAndPopulate(requestId, selectedRiders, usePriority) {
       updateAssignmentRotation(assignedRiderNames);
     }
 
+    // Post assignments to calendar to ensure assigned riders appear in calendar events
+    if (typeof postAssignmentsToCalendar === 'function') {
+      try {
+        postAssignmentsToCalendar();
+      } catch (calendarError) {
+        logError('Failed to post assignments to calendar', calendarError);
+      }
+    }
+
     // Clear caches to ensure fresh data
     clearRequestsCache();
     clearDataCache();

--- a/CALENDAR_RIDER_ASSIGNMENT_FIX.md
+++ b/CALENDAR_RIDER_ASSIGNMENT_FIX.md
@@ -1,0 +1,79 @@
+# Calendar Rider Assignment Fix
+
+## Issue
+Escorts listed in the calendar did not have the assigned riders displayed in the calendar event entries. While riders were being assigned to requests, their names were not appearing in the calendar event descriptions.
+
+## Root Cause Analysis
+
+The system had two calendar sync mechanisms:
+
+1. **`syncRequestToCalendar()`** - Syncs individual requests to calendar
+2. **`postAssignmentsToCalendar()`** - Designed to sync all assignments with "Assigned" status to calendar
+
+### Problems Identified:
+
+1. **Missing Function Call**: The `postAssignmentsToCalendar()` function was defined but never called anywhere in the system
+2. **Incomplete Menu Integration**: No menu item existed to manually trigger assignment-to-calendar sync
+3. **Missing Automatic Sync**: When rider assignments were made, only `syncRequestToCalendar()` was called, but there may have been timing or coordination issues preventing consistent rider display
+
+## Solution Implemented
+
+### 1. Added Menu Item
+**File: `Menu.gs`**
+- Added "📝 Post Assignments to Calendar" menu item to allow manual triggering of assignment sync
+
+### 2. Automatic Assignment Sync
+**File: `AppServices.gs`**
+- Added call to `postAssignmentsToCalendar()` after rider assignments are made
+- Ensures that whenever riders are assigned to requests, the calendar events are updated to show assigned riders
+
+### 3. Status Change Calendar Sync
+**File: `SheetServices.gs`**
+- Added calendar sync trigger when request status automatically changes to "Assigned"
+- Ensures calendar is updated when status changes due to rider assignments
+
+## How It Works
+
+### Calendar Event Description Format
+When riders are assigned, the calendar event description includes:
+```
+Request ID: [ID]
+From: [Start Location]
+To: [End Location]
+Notes: [Notes]
+Assigned Riders: [Rider1, Rider2, ...]
+```
+
+### Assignment Flow
+1. Riders are assigned to a request
+2. `updateRequestWithAssignedRiders()` updates the request record
+3. `postAssignmentsToCalendar()` is called to sync assignments to calendar
+4. `syncRequestToCalendar()` updates the specific request's calendar event
+5. Calendar event description now shows assigned riders
+
+### Manual Sync Options
+Users can manually trigger calendar sync using:
+- **🔄 Sync All Assigned to Calendar** - Syncs all assigned requests
+- **📝 Post Assignments to Calendar** - Syncs all assignments with "Assigned" status
+
+## Files Modified
+
+1. **`Menu.gs`** - Added menu item for manual assignment sync
+2. **`AppServices.gs`** - Added automatic `postAssignmentsToCalendar()` call after assignments
+3. **`SheetServices.gs`** - Added calendar sync when status changes to "Assigned"
+
+## Testing
+
+To verify the fix:
+1. Assign riders to an escort request
+2. Check the calendar event - assigned riders should appear in the description
+3. Use manual sync menu items if needed
+4. Verify that status changes to "Assigned" also trigger calendar updates
+
+## Benefits
+
+- ✅ Assigned riders now appear consistently in calendar events
+- ✅ Multiple sync mechanisms ensure reliability
+- ✅ Manual override options available for administrators
+- ✅ Automatic sync prevents missing rider information
+- ✅ Improved visibility for escort coordination

--- a/Menu.gs
+++ b/Menu.gs
@@ -60,6 +60,7 @@ function createMenu() {
     .addItem('📊 Notification Report', 'generateNotificationReport')
     .addSeparator()
     .addItem('🔄 Sync All Assigned to Calendar', 'syncAllAssignedRequestsToCalendar')
+    .addItem('📝 Post Assignments to Calendar', 'postAssignmentsToCalendar')
     .addSeparator()
     .addItem('Generate Missing Request IDs', 'generateAllMissingRequestIds')
     .addToUi();

--- a/SheetServices.gs
+++ b/SheetServices.gs
@@ -754,6 +754,15 @@ function updateRequestStatusBasedOnRiders(requestId) {
             requestsData.sheet.getRange(requestRowIndex, lastUpdatedColIdx + 1).setValue(new Date());
         }
         logActivity(`Status automatically updated for request ${requestId} to ${determinedNewStatus}.`);
+        
+        // Sync calendar when status changes to 'Assigned' to ensure riders appear in calendar events
+        if (determinedNewStatus === 'Assigned' && typeof syncRequestToCalendar === 'function') {
+          try {
+            syncRequestToCalendar(requestId);
+          } catch (syncError) {
+            logError(`Failed to sync request ${requestId} to calendar after status update`, syncError);
+          }
+        }
       } else {
         logError(`Could not update status for ${requestId}: Status column or row index invalid.`);
       }


### PR DESCRIPTION
Integrate assignment sync functions to ensure assigned riders are displayed in calendar events.

The `postAssignmentsToCalendar()` function, designed to sync rider assignments to the calendar, was previously uncalled. This PR integrates it into the assignment process and adds a manual trigger, resolving the issue of missing rider information in calendar entries.