### PR TITLE
Treat cancelled requests as completed

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -606,7 +606,10 @@ function getAdminDashboardData() {
     }
     
     const result = {
-      totalRequests: requests.filter(r => String(r.status || r['Status']).trim() !== 'Completed').length,
+      totalRequests: requests.filter(r => {
+        const status = String(r.status || r['Status']).trim();
+        return status !== 'Completed' && status !== 'Cancelled';
+      }).length,
       totalRiders: activeRiders,
       totalAssignments: assignments.length,
       pendingNotifications: pendingNotifications,

--- a/Code.gs
+++ b/Code.gs
@@ -2446,7 +2446,7 @@ function appendEmailResponseToAssignments(riderName, messageBody) {
       const assignmentRider = row[riderCol];
       const status = statusCol !== undefined ? row[statusCol] : '';
 
-      if (assignmentRider === riderName && status !== 'Completed') {
+      if (assignmentRider === riderName && status !== 'Completed' && status !== 'Cancelled') {
         const rowNumber = i + 2; // Account for header row
         const existingNote = row[notesCol] || '';
         const newNote = existingNote ? existingNote + '\n' + noteText : noteText;

--- a/requests.html
+++ b/requests.html
@@ -1258,7 +1258,7 @@
             }
 
             if (hideCompleted) {
-                allRequests = allRequests.filter(r => r.status !== 'Completed');
+                allRequests = allRequests.filter(r => r.status !== 'Completed' && r.status !== 'Cancelled');
             }
 
             // Build the requester lookup cache from all requests data


### PR DESCRIPTION
Align the handling of 'Cancelled' escort requests with 'Completed' requests for filtering, counting, and updates.