### PR TITLE
Align cancelled requests with completed display

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -590,7 +590,7 @@
             <label><strong>Date:</strong></label>
             <input type="date" id="dateFilter" title="Filter by event date">
             <button onclick="clearDateFilter()" title="Clear date filter">🗑️</button>
-            <label><input type="checkbox" id="showCompleted"> Completed</label>
+            <label><input type="checkbox" id="showCompleted"> Completed & Cancelled</label>
             <button onclick="loadPageData()">🔄 Refresh</button>
             <button onclick="exportToCSV()">📊 Export</button>
             <button class="btn-success add-request-btn" onclick="openNewRequestForm()">➕ Add New Request</button>


### PR DESCRIPTION
Update the "Completed" checkbox label to "Completed & Cancelled" to accurately reflect its control over both request types.