### PR TITLE
Fix escortFee trim error in email notification

### DIFF
--- a/NotificationService.gs
+++ b/NotificationService.gs
@@ -94,13 +94,13 @@ function handleEnhancedNotificationAction(e, dashSheet, row) {
     } else if (selectedAction.includes('Send Both to All')) {
       sendNotificationsToRequest(requestId, 'Both');
     } else if (selectedAction.includes('SMS →')) {
-      const riderName = selectedAction.split('→')[1].trim();
+      const riderName = (selectedAction.split('→')[1] || '').trim();
       sendIndividualNotification(requestId, riderName, 'SMS');
     } else if (selectedAction.includes('Email →')) {
-      const riderName = selectedAction.split('→')[1].trim();
+      const riderName = (selectedAction.split('→')[1] || '').trim();
       sendIndividualNotification(requestId, riderName, 'Email');
     } else if (selectedAction.includes('Both →')) {
-      const riderName = selectedAction.split('→')[1].trim();
+      const riderName = (selectedAction.split('→')[1] || '').trim();
       sendIndividualNotification(requestId, riderName, 'Both');
     } else if (selectedAction.includes('Mark All as Notified')) {
       markRequestAsNotified(requestId);
@@ -849,16 +849,16 @@ function formatNotificationMessage(assignment, includeLinks = true) {
   const requestDetails = getRequestDetailsForNotification(requestId);
   
   if (requestDetails) {
-    if (requestDetails.escortFee && requestDetails.escortFee.trim()) {
-      message += `\n💰 Fee: ${requestDetails.escortFee.trim()}\n`;
+    if (requestDetails.escortFee && String(requestDetails.escortFee).trim()) {
+      message += `\n💰 Fee: ${String(requestDetails.escortFee).trim()}\n`;
     }
     
     if (requestDetails.courtesy === 'Yes') {
       message += `⭐ COURTESY REQUEST ⭐\n`;
     }
     
-    if (requestDetails.notes && requestDetails.notes.trim()) {
-      message += `📝 Notes: ${requestDetails.notes.trim()}\n`;
+    if (requestDetails.notes && String(requestDetails.notes).trim()) {
+      message += `📝 Notes: ${String(requestDetails.notes).trim()}\n`;
     }
   }
   
@@ -1164,7 +1164,7 @@ function handleSMSWebhook(e) {
  */
 function processSMSResponse(fromNumber, messageBody, messageSid) {
   try {
-    const cleanMessage = messageBody.trim().toLowerCase();
+    const cleanMessage = String(messageBody || '').trim().toLowerCase();
     
     // Find the rider by phone number
     const rider = findRiderByPhone(fromNumber);


### PR DESCRIPTION
Safely handle `trim()` calls on potentially null or undefined values to prevent runtime errors.

The `trim()` method was being called directly on variables that could be `null` or `undefined` (e.g., `escortFee` from `getColumnValue`, results of `split()` operations, or external `messageBody` parameters). This led to "trim is not a function" errors, crashing the notification process. By converting these values to strings (e.g., `String(value || '')`) before calling `trim()`, the code now gracefully handles missing or empty data.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-e3f349e1-38e7-4d76-b650-e23472a20160) · [Cursor](https://cursor.com/background-agent?bcId=bc-e3f349e1-38e7-4d76-b650-e23472a20160)