### PR TITLE
Add HTML email notifications with confirm/decline links

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -4355,7 +4355,16 @@ function debugNotificationsFile() {
 function doGet(e) {
   try {
     console.log('🚀 doGet with cache-friendly headers...');
-    
+
+    if (e.parameter && e.parameter.action === 'respondAssignment') {
+      const assignmentId = e.parameter.assignmentId;
+      const resp = String(e.parameter.response || '').toLowerCase();
+      const status = resp === 'confirm' ? 'Confirmed' : 'Declined';
+      const result = updateAssignmentStatusById(assignmentId, status, 'Link');
+      const message = result.success ? `Your response has been recorded as ${status}.` : 'Unable to record response.';
+      return HtmlService.createHtmlOutput(`<p>${message}</p>`).setTitle('Escort Response');
+    }
+
     // Authentication and page logic (your existing code)
     const authResult = authenticateAndAuthorizeUser();
     if (!authResult.success) {


### PR DESCRIPTION
## Summary
- format email notifications with escort info and action buttons
- send HTML emails using new format
- allow assignment confirmation via `respondAssignment` link in `doGet`

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_687c09492eec832396f5b33c955399cd