### PR TITLE
Fix for alert prefix on bulk notification results

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -1521,7 +1521,10 @@ function convertAssignmentsToNotificationFormat(assignments) {
 
 ${result.message || 'Completed'}`;
             
-            alert(message);
+            // Use custom notification instead of browser alert
+            // to avoid the default "An embedded page at..." prefix
+            // that appears when using alert() inside an iframe.
+            showMessage(message, 'info');
         }
 
         function clearAllFilters() {


### PR DESCRIPTION
## Summary
- avoid browser alert prefix by using in-page notification for bulk results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687c0bc029a48323aaae3757306fd837