### PR TITLE
Fix null user handling in updateUserInfoSafely

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,6 +514,7 @@
 
     function updateUserInfoSafely(user) {
         try {
+            const safeUser = user || {};
             const safeUpdate = (id, value, property = 'textContent') => {
                 try {
                     const element = document.getElementById(id);
@@ -528,9 +529,9 @@
                 }
             };
 
-            safeUpdate('userName', user.name || 'User');
-            safeUpdate('userRole', (user.roles || ['user']).join(', '));
-            safeUpdate('userAvatar', (user.name || 'U').charAt(0).toUpperCase());
+            safeUpdate('userName', safeUser.name || 'User');
+            safeUpdate('userRole', (safeUser.roles || ['user']).join(', '));
+            safeUpdate('userAvatar', (safeUser.name || 'U').charAt(0).toUpperCase());
         } catch (error) {
             console.log('❌ Error in updateUserInfoSafely:', error);
         }

--- a/notifications.html
+++ b/notifications.html
@@ -739,6 +739,7 @@
 
         function updateUserInfoSafely(user) {
             try {
+                const safeUser = user || {};
                 const safeUpdate = (id, value) => {
                     try {
                         const element = document.getElementById(id);
@@ -751,9 +752,9 @@
                     }
                 };
 
-                safeUpdate('userName', user.name || 'User');
-                safeUpdate('userRole', (user.roles || ['user']).join(', '));
-                safeUpdate('userAvatar', (user.name || 'U').charAt(0).toUpperCase());
+                safeUpdate('userName', safeUser.name || 'User');
+                safeUpdate('userRole', (safeUser.roles || ['user']).join(', '));
+                safeUpdate('userAvatar', (safeUser.name || 'U').charAt(0).toUpperCase());
             } catch (error) {
                 console.log('Error in updateUserInfoSafely:', error);
             }

--- a/reports.html
+++ b/reports.html
@@ -647,6 +647,7 @@
 
         function updateUserInfoSafely(user) {
             try {
+                var safeUser = user || {};
                 var safeUpdate = function(id, value, property) {
                     property = property || 'textContent';
                     try {
@@ -659,9 +660,9 @@
                     }
                 };
 
-                safeUpdate('userName', user.name || 'User');
-                safeUpdate('userRole', (user.roles || ['user']).join(', '));
-                safeUpdate('userAvatar', (user.name || 'U').charAt(0).toUpperCase());
+                safeUpdate('userName', safeUser.name || 'User');
+                safeUpdate('userRole', (safeUser.roles || ['user']).join(', '));
+                safeUpdate('userAvatar', (safeUser.name || 'U').charAt(0).toUpperCase());
             } catch (error) {
                 console.log('Error in updateUserInfoSafely:', error);
             }


### PR DESCRIPTION
## Summary
- guard against null `user` in `updateUserInfoSafely` across HTML pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e2dd1f1888323bfde81268c0aa804