### PR TITLE
Fix notifications not updating from cache

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -2671,9 +2671,9 @@ function getPageDataForNotifications() { // Removed user parameter
       };
     }
     
-    // Get all assignments for notifications
+    // Get all assignments for notifications (force fresh data)
     try {
-      result.assignments = getAllAssignmentsForNotifications();
+      result.assignments = getAllAssignmentsForNotifications(false);
       console.log(`✅ Loaded ${result.assignments.length} assignments for notifications`);
     } catch (assignmentsError) {
       console.log('⚠️ Could not load assignments:', assignmentsError);
@@ -2724,9 +2724,9 @@ function getPageDataForNotifications() { // Removed user parameter
  * Gets all assignments formatted for notifications page
  * @return {Array<object>} Array of assignment objects with notification data
  */
-function getAllAssignmentsForNotifications() {
+function getAllAssignmentsForNotifications(useCache = true) {
   try {
-    const assignmentsData = getAssignmentsData();
+    const assignmentsData = getAssignmentsData(useCache);
     if (!assignmentsData || !assignmentsData.data) {
       console.log('⚠️ No assignments data found');
       return [];
@@ -4854,7 +4854,7 @@ function testNotificationDataLoading() {
     
     // Test 3: Test getAllAssignmentsForNotifications
     try {
-      const notificationAssignments = getAllAssignmentsForNotifications();
+      const notificationAssignments = getAllAssignmentsForNotifications(false);
       results.tests.notificationAssignmentsCount = notificationAssignments?.length || 0;
       results.tests.getAllAssignmentsForNotificationsSuccess = true;
     } catch (error) {

--- a/NotificationService.gs
+++ b/NotificationService.gs
@@ -1535,11 +1535,11 @@ function getRequestDetailsForNotification(requestId) {
  * Returns all assignments data structured for the notifications page.
  * @returns {Array<Object>} An array of assignment objects.
  */
-function getAllAssignmentsForNotifications() {
+function getAllAssignmentsForNotifications(useCache = true) {
   try {
     console.log('📋 Getting all assignments for notifications...');
-    
-    const assignmentsData = getAssignmentsData(); // This gets actual assignments
+
+    const assignmentsData = getAssignmentsData(useCache); // This gets actual assignments
     
     if (!assignmentsData || !assignmentsData.data || assignmentsData.data.length === 0) {
       console.log('❌ No assignments data found');
@@ -1897,7 +1897,7 @@ function getEnhancedNotificationStats() {
     });
     
     // Get processed assignments for the notifications page
-    const processedAssignments = getAllAssignmentsForNotifications();
+    const processedAssignments = getAllAssignmentsForNotifications(false);
     
     const stats = {
       totalAssignments: totalAssignments,

--- a/notifications_assignment_fix.gs
+++ b/notifications_assignment_fix.gs
@@ -128,7 +128,7 @@ function debugAssignmentsSheetState() {
     }
     
     // Check 5: Test getAllAssignmentsForNotifications function
-    const notificationAssignments = getAllAssignmentsForNotifications();
+    const notificationAssignments = getAllAssignmentsForNotifications(false);
     if (!notificationAssignments || notificationAssignments.length === 0) {
       issues.push('getAllAssignmentsForNotifications_returns_empty');
     }
@@ -314,7 +314,7 @@ function verifyAssignmentLoading() {
     console.log(`📊 getAssignmentsData returned ${assignmentsData.data?.length || 0} rows`);
     
     // Test getAllAssignmentsForNotifications
-    const notificationAssignments = getAllAssignmentsForNotifications();
+    const notificationAssignments = getAllAssignmentsForNotifications(false);
     console.log(`📊 getAllAssignmentsForNotifications returned ${notificationAssignments?.length || 0} assignments`);
     
     // Test the full getPageDataForNotifications function
@@ -362,7 +362,7 @@ function quickFixAssignments() {
     dataCache.clear('sheet_' + CONFIG.sheets.riders);
     
     // Test the result
-    const assignments = getAllAssignmentsForNotifications();
+    const assignments = getAllAssignmentsForNotifications(false);
     
     return {
       success: assignments && assignments.length > 0,


### PR DESCRIPTION
## Summary
- bypass caching when loading assignments for notifications
- support an optional `useCache` parameter in assignment helpers
- force fresh data when verifying notification fixes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ea3dd47308323a60efc8ce02d7773