### PR TITLE
Resolve notifications page trim error

### DIFF
--- a/RequestCRUD.gs
+++ b/RequestCRUD.gs
@@ -2502,11 +2502,11 @@ function getAllRequestsForLookup() {
         const request = {};
         
         // Map only the fields needed for lookup functionality
-        request.requestId = getColumnValue(row, columnMap, CONFIG.columns.requests.id) || '';
-        request.requesterName = getColumnValue(row, columnMap, CONFIG.columns.requests.requesterName) || '';
-        request.requesterContact = getColumnValue(row, columnMap, CONFIG.columns.requests.requesterContact) || '';
-        request.eventDate = getColumnValue(row, columnMap, CONFIG.columns.requests.eventDate) || '';
-        request.status = getColumnValue(row, columnMap, CONFIG.columns.requests.status) || '';
+        request.requestId = String(getColumnValue(row, columnMap, CONFIG.columns.requests.id) || '');
+        request.requesterName = String(getColumnValue(row, columnMap, CONFIG.columns.requests.requesterName) || '');
+        request.requesterContact = String(getColumnValue(row, columnMap, CONFIG.columns.requests.requesterContact) || '');
+        request.eventDate = String(getColumnValue(row, columnMap, CONFIG.columns.requests.eventDate) || '');
+        request.status = String(getColumnValue(row, columnMap, CONFIG.columns.requests.status) || '');
         
         // Format event date for consistent sorting
         if (request.eventDate) {
@@ -2523,7 +2523,8 @@ function getAllRequestsForLookup() {
         return request;
       }).filter(request => {
         // Only include requests that have both requester name and contact info
-        return request.requesterName.trim() && request.requesterContact.trim();
+        return request.requesterName && request.requesterName.trim() && 
+               request.requesterContact && request.requesterContact.trim();
       });
 
       debugLog(`Returning ${requests.length} requests for lookup cache`);


### PR DESCRIPTION
Fix `TypeError` by safeguarding `trim()` calls on potentially null/undefined values.

The `TypeError` occurred because `request.requesterContact` (and other fields) could be `null` or `undefined` after retrieval from `getColumnValue`, causing `.trim()` to be called on a non-string value in the filter logic. This PR ensures all relevant fields are explicitly converted to strings and adds robust null/undefined checks before calling `.trim()`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e2262165-a90d-49c6-89c7-870e1f16c27d) · [Cursor](https://cursor.com/background-agent?bcId=bc-e2262165-a90d-49c6-89c7-870e1f16c27d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)