### PR TITLE
Fix notifications page cache issue

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -2922,7 +2922,7 @@ function getPageDataForNotifications(user) {
     
     // Get all assignments for notifications
     try {
-      result.assignments = getAllAssignmentsForNotifications();
+      result.assignments = getAllAssignmentsForNotifications(false);
       console.log(`✅ Loaded ${result.assignments.length} assignments for notifications`);
     } catch (assignmentsError) {
       console.log('⚠️ Could not load assignments:', assignmentsError);
@@ -3065,7 +3065,7 @@ function debugAssignmentLoading() {
     
     // STEP 4: Test the actual getAllAssignmentsForNotifications function
     console.log('\n--- STEP 4: Testing getAllAssignmentsForNotifications ---');
-    const filteredAssignments = getAllAssignmentsForNotifications();
+    const filteredAssignments = getAllAssignmentsForNotifications(false);
     result.step4_finalResult = {
       filteredCount: filteredAssignments.length,
       sampleAssignments: filteredAssignments.slice(0, 3)
@@ -3120,7 +3120,7 @@ function testNotificationsData() {
     console.log('Auth result:', auth.success);
     
     // Test assignments loading
-    const assignments = getAllAssignmentsForNotifications();
+    const assignments = getAllAssignmentsForNotifications(false);
     console.log(`Assignments found: ${assignments.length}`);
     
     if (assignments.length > 0) {
@@ -3159,11 +3159,11 @@ function testNotificationsData() {
 /**
  * Gets all assignments formatted for notifications page
  */
-function getAllAssignmentsForNotifications() {
+function getAllAssignmentsForNotifications(useCache = true) {
   try {
     console.log('📋 Getting all assignments for notifications...');
-    
-    const assignmentsData = getAssignmentsData();
+
+    const assignmentsData = getAssignmentsData(useCache);
     if (!assignmentsData || !assignmentsData.data) {
       console.log('⚠️ No assignments data found');
       return [];

--- a/NotificationService.gs
+++ b/NotificationService.gs
@@ -1535,11 +1535,11 @@ function getRequestDetailsForNotification(requestId) {
  * Returns all assignments data structured for the notifications page.
  * @returns {Array<Object>} An array of assignment objects.
  */
-function getAllAssignmentsForNotifications() {
+function getAllAssignmentsForNotifications(useCache = true) {
   try {
     console.log('📋 Getting all assignments for notifications...');
-    
-    const assignmentsData = getAssignmentsData(); // This gets actual assignments
+
+    const assignmentsData = getAssignmentsData(useCache); // This gets actual assignments
     
     if (!assignmentsData || !assignmentsData.data || assignmentsData.data.length === 0) {
       console.log('❌ No assignments data found');
@@ -1897,7 +1897,7 @@ function getEnhancedNotificationStats() {
     });
     
     // Get processed assignments for the notifications page
-    const processedAssignments = getAllAssignmentsForNotifications();
+    const processedAssignments = getAllAssignmentsForNotifications(false);
     
     const stats = {
       totalAssignments: totalAssignments,
@@ -2100,7 +2100,7 @@ function runImmediateAssignmentFix() {
     dataCache.clear('sheet_' + CONFIG.sheets.assignments);
     dataCache.clear('sheet_' + CONFIG.sheets.riders);
     
-    const finalAssignments = getAllAssignmentsForNotifications();
+    const finalAssignments = getAllAssignmentsForNotifications(false);
     console.log(`✅ Final result: ${finalAssignments.length} assignments loaded for notifications`);
     
     if (finalAssignments.length > 0) {
@@ -2141,7 +2141,7 @@ function checkAssignmentLoadingStatus() {
     console.log(`Raw assignments data: ${rawData.data ? rawData.data.length : 0} rows`);
     
     // Test getAllAssignmentsForNotifications
-    const notificationAssignments = getAllAssignmentsForNotifications();
+    const notificationAssignments = getAllAssignmentsForNotifications(false);
     console.log(`Notification assignments: ${notificationAssignments.length} items`);
     
     // Test getPageDataForNotifications


### PR DESCRIPTION
## Summary
- avoid stale notification data by passing through cache flag
- refresh stats calculations with latest assignments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ebdcf74648323adbd959f8a412951