### PR TITLE
Reapply assignment timeout enhancements

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -2136,6 +2136,13 @@ function updateAssignmentOrder() {
             return;
         }
 
+        // Warn for large assignments that might take longer
+        if (selectedRiders.size > 10) {
+            if (!confirm(`You are assigning ${selectedRiders.size} riders to this request. Large assignments may take longer to process. Continue?`)) {
+                return;
+            }
+        }
+
         var ridersArray = [];
         selectedRiders.forEach(function(name) {
             var rider = null;
@@ -2153,24 +2160,65 @@ function updateAssignmentOrder() {
             });
         });
 
-        showLoading('Saving assignment...');
+        // Show appropriate loading message based on assignment size
+        const riderCount = ridersArray.length;
+        let loadingMessage = 'Saving assignment...';
+        if (riderCount > 10) {
+            loadingMessage = `Saving large assignment (${riderCount} riders)... This may take up to 2 minutes.`;
+        } else if (riderCount > 5) {
+            loadingMessage = `Saving assignment (${riderCount} riders)... This may take a moment.`;
+        }
+        showLoading(loadingMessage);
 
         try {
-            // Set a timeout to handle cases where the script doesn't respond
+            let hasCompleted = false;
+
+            // Improved timeout handling with progress indicators
             const timeoutId = setTimeout(() => {
-                hideLoading();
-                showError('Assignment save timed out. Please check if the assignment was saved and refresh the page.');
-                console.log('Assignment save operation timed out after 60 seconds');
-            }, 60000); // 60 second timeout
+                if (!hasCompleted) {
+                    hideLoading();
+                    showError('Assignment save is taking longer than expected. The assignment may still be processing in the background. Please wait a moment and refresh the page to check if it was saved.');
+                    console.log('Assignment save operation timed out after 120 seconds');
+                }
+            }, 120000); // 120 second timeout - increased from 60s to accommodate larger assignments
+
+            // Show progress indicator after 10 seconds
+            const progressTimeoutId = setTimeout(() => {
+                if (!hasCompleted) {
+                    showLoading('Still saving assignment... This may take a moment for large assignments.');
+                }
+            }, 10000);
+
+            // Show extended progress indicator after 30 seconds for large assignments
+            const extendedProgressTimeoutId = setTimeout(() => {
+                if (!hasCompleted && riderCount > 10) {
+                    showLoading(`Processing large assignment (${riderCount} riders)... Almost done. Please wait...`);
+                }
+            }, 30000);
+
+            // Show final progress indicator after 60 seconds
+            const finalProgressTimeoutId = setTimeout(() => {
+                if (!hasCompleted) {
+                    showLoading('Assignment is taking longer than usual... Please continue waiting, it should complete soon.');
+                }
+            }, 60000);
 
             google.script.run
                 .withSuccessHandler((result) => {
+                    hasCompleted = true;
                     clearTimeout(timeoutId);
+                    clearTimeout(progressTimeoutId);
+                    clearTimeout(extendedProgressTimeoutId);
+                    clearTimeout(finalProgressTimeoutId);
                     hideLoading();
                     handleAssignmentSuccess(result);
                 })
                 .withFailureHandler((error) => {
+                    hasCompleted = true;
                     clearTimeout(timeoutId);
+                    clearTimeout(progressTimeoutId);
+                    clearTimeout(extendedProgressTimeoutId);
+                    clearTimeout(finalProgressTimeoutId);
                     hideLoading();
                     handleError(error);
                 })

--- a/requests.html
+++ b/requests.html
@@ -2238,7 +2238,15 @@
         console.log('Saving rider assignments for request:', requestId);
         console.log('Selected riders:', selectedRidersArray);
 
-        showLoadingOverlay();
+        // Show appropriate loading message based on assignment size
+        const riderCount = selectedRidersArray.length;
+        if (riderCount > 10) {
+            showLoadingOverlay(`Saving large assignment (${riderCount} riders)... This may take up to 2 minutes.`);
+        } else if (riderCount > 5) {
+            showLoadingOverlay(`Saving assignment (${riderCount} riders)... This may take a moment.`);
+        } else {
+            showLoadingOverlay('Saving rider assignments...');
+        }
 
         // Create rider objects for the assignment function
         const riderObjects = selectedRidersArray.map(riderName => {
@@ -2252,20 +2260,53 @@
         });
 
         if (typeof google !== 'undefined' && google.script && google.script.run) {
-            // Set a timeout to handle cases where the script doesn't respond
+            let hasCompleted = false;
+
+            // Improved timeout handling with progress indicators
             const timeoutId = setTimeout(() => {
-                hideLoadingOverlay();
-                showToast('Assignment save timed out. Please check if the assignment was saved and refresh the page.', 8000);
-                console.log('Assignment save operation timed out after 60 seconds');
-            }, 60000); // 60 second timeout
+                if (!hasCompleted) {
+                    hideLoadingOverlay();
+                    showToast('Assignment save is taking longer than expected. The assignment may still be processing in the background. Please wait a moment and refresh the page to check if it was saved.', 10000);
+                    console.log('Assignment save operation timed out after 120 seconds');
+                }
+            }, 120000); // 120 second timeout - increased from 60s to accommodate larger assignments
+
+            // Show progress indicator after 10 seconds
+            const progressTimeoutId = setTimeout(() => {
+                if (!hasCompleted) {
+                    showToast('Still saving assignment... This may take a moment for large assignments.', 5000);
+                }
+            }, 10000);
+
+            // Show extended progress indicator after 30 seconds for large assignments
+            const extendedProgressTimeoutId = setTimeout(() => {
+                if (!hasCompleted && riderCount > 10) {
+                    showToast(`Processing large assignment (${riderCount} riders)... Almost done. Please wait...`, 5000);
+                }
+            }, 30000);
+
+            // Show final progress indicator after 60 seconds
+            const finalProgressTimeoutId = setTimeout(() => {
+                if (!hasCompleted) {
+                    showToast('Assignment is taking longer than usual... Please continue waiting, it should complete soon.', 5000);
+                }
+            }, 60000);
 
             google.script.run
                 .withSuccessHandler((result) => {
+                    hasCompleted = true;
                     clearTimeout(timeoutId);
+                    clearTimeout(progressTimeoutId);
+                    clearTimeout(extendedProgressTimeoutId);
+                    clearTimeout(finalProgressTimeoutId);
                     handleAssignmentSaveSuccess(result);
                 })
                 .withFailureHandler((error) => {
+                    hasCompleted = true;
                     clearTimeout(timeoutId);
+                    clearTimeout(progressTimeoutId);
+                    clearTimeout(extendedProgressTimeoutId);
+                    clearTimeout(finalProgressTimeoutId);
                     handleAssignmentSaveError(error);
                 })
                 .processAssignmentAndPopulate(requestId, riderObjects, true);


### PR DESCRIPTION
## Summary
- extend assignment save timeout to 120s
- add progressive timeout feedback in assignments and requests pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f95230bc48323a0342b441a0779de