### PR TITLE
Fix rider assignment modal permissions

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -266,7 +266,7 @@ function getPageDataForRiders(user, filters = {}) {
       return { success: false, error: 'Authentication required' };
     }
     
-    if (!canAccessPage(user, 'riders')) {
+    if (!canAccessPage(user, 'riders') && !hasPermission(user, 'assignments', 'assign_any')) {
       return { success: false, error: 'Access denied to riders' };
     }
     


### PR DESCRIPTION
## Summary
- allow dispatchers to retrieve rider data when assigning riders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688111e975308323b904e3d268b2e49d