### PR TITLE
Fix rider list loader for assignment modal

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -2017,9 +2017,11 @@
 
     function handleRidersDataLoaded(data) {
         document.getElementById('ridersLoadingState').style.display = 'none';
-        
-        if (data && data.success && data.riders) {
-            availableRiders = data.riders.filter(rider => {
+
+        const ridersList = (data && data.riders) || (data && data.data && data.data.riders);
+
+        if (data && data.success && Array.isArray(ridersList)) {
+            availableRiders = ridersList.filter(rider => {
                 const status = String(rider.status || '').toLowerCase().trim();
                 return status === '' ||
                        status.startsWith('active') ||


### PR DESCRIPTION
## Summary
- handle both response shapes when loading riders for request assignments

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6881292347e48323a1f4cbfbd40fd871