### PR TITLE
Unify assignment and notification email formats

### DIFF
--- a/NotificationService.gs
+++ b/NotificationService.gs
@@ -184,6 +184,7 @@ function sendPreAssignmentEmail(requestId, riderName) {
     const ridersData = getRidersData();
     const nameIdx = ridersData.columnMap[CONFIG.columns.riders.name];
     const emailIdx = ridersData.columnMap[CONFIG.columns.riders.email];
+    const jpNumberIdx = ridersData.columnMap[CONFIG.columns.riders.jpNumber];
     const riderRow = ridersData.data.find(r => r[nameIdx] === riderName);
     if (!riderRow) {
       return { success: false, message: 'Rider not found' };
@@ -194,13 +195,32 @@ function sendPreAssignmentEmail(requestId, riderName) {
       return { success: false, message: 'No email for rider' };
     }
 
-    const dateStr = formatDateForDisplay(request.eventDate);
-    const timeStr = formatTimeForDisplay(request.startTime);
-    const msg =
-      `You have been proposed for escort request ${request.id} on ${dateStr} at ${timeStr}.\n` +
-      `Start: ${request.startLocation || ''}${request.endLocation ? ' → ' + request.endLocation : ''}`;
+    const jpNumber = riderRow[jpNumberIdx] || '';
 
-    return sendEmail(email, `Proposed Escort Assignment ${request.id}`, msg, msg);
+    // Use the same format as the notification page by calling formatEmailNotification
+    const currentRider = { name: riderName, jpNumber: jpNumber };
+    const allRiders = [currentRider];
+
+    // Generate temporary assignment ID for confirm/decline URLs
+    const tempAssignmentId = `temp_${requestId}_${riderName.replace(/\s+/g, '_')}`;
+    const confirmUrl = `${getWebAppUrl()}?action=respondAssignment&assignmentId=${tempAssignmentId}&response=confirm`;
+    const declineUrl = `${getWebAppUrl()}?action=respondAssignment&assignmentId=${tempAssignmentId}&response=decline`;
+
+    const requestDetails = getRequestDetailsForNotification(requestId) || {};
+    const formatted = formatEmailNotification({
+      requestId: request.id,
+      eventDate: requestDetails.eventDate || request.eventDate,
+      startTime: requestDetails.startTime || request.startTime,
+      startLocation: requestDetails.startLocation || request.startLocation,
+      endLocation: requestDetails.endLocation || request.endLocation,
+      secondaryLocation: requestDetails.secondaryLocation,
+      requesterName: requestDetails.requesterName,
+      requesterContact: requestDetails.requesterContact,
+      escortFee: requestDetails.escortFee,
+      notes: requestDetails.notes
+    }, allRiders, confirmUrl, declineUrl);
+
+    return sendEmail(email, `Assignment ${tempAssignmentId} - ${request.id}`, formatted.text, formatted.html);
   } catch (err) {
     logError('Error sending pre-assignment email', err);
     return { success: false, message: err.message };


### PR DESCRIPTION
Refactor `sendPreAssignmentEmail` to use `formatEmailNotification` for consistent and detailed pre-assignment emails.

---

[Open in Web](https://www.cursor.com/agents?id=bc-2bd52483-326d-4242-b882-78fe85cf1ab4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2bd52483-326d-4242-b882-78fe85cf1ab4)