### PR TITLE
Fix assignment processing when request missing

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -4312,7 +4312,11 @@ function updateRequestWithAssignedRiders(requestId, riderNames) {
     }
 
     if (targetRowIndex === -1) {
-      throw new Error(`Request ${requestId} not found for rider assignment update`);
+      logError(
+        `Request ${requestId} not found for rider assignment update`,
+        new Error('RequestNotFound')
+      );
+      return; // Gracefully exit if request row is missing
     }
 
     const sheetRowNumber = targetRowIndex + 2; // Convert to 1-based row number


### PR DESCRIPTION
## Summary
- avoid error when request row is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882885beb008323a16d93947dfd7ccc