### PR TITLE
Fix request type validation

### DIFF
--- a/HeaderProtection.gs
+++ b/HeaderProtection.gs
@@ -291,7 +291,7 @@ function setupDataValidationForDataRowsOnlyFixed(sheet, headers) {
       if (typeColIndex >= 0 && lastRow > 1) {
         const typeRange = sheet.getRange(2, typeColIndex + 1, lastRow - 1, 1);
         const typeValidation = SpreadsheetApp.newDataValidation()
-          .requireValueInList(['Funeral', 'Wedding', 'Parade', 'VIP', 'Emergency', 'Training', 'Other'])
+          .requireValueInList(CONFIG.options.requestTypes)
           .setAllowInvalid(false)
           .setHelpText('Select request type')
           .build();

--- a/temprun.gs
+++ b/temprun.gs
@@ -585,7 +585,7 @@ function setupRequestsDataValidationCorrected(sheet, headers) {
     if (typeColIndex >= 0 && lastRow > 1) {
       const typeRange = sheet.getRange(2, typeColIndex + 1, lastRow - 1, 1);
       const typeValidation = SpreadsheetApp.newDataValidation()
-        .requireValueInList(['Funeral', 'Wedding', 'Parade', 'VIP', 'Emergency', 'Training', 'Other'])
+        .requireValueInList(CONFIG.options.requestTypes)
         .setAllowInvalid(false)
         .setHelpText('Select request type')
         .build();


### PR DESCRIPTION
## Summary
- use centralized request type options for sheet validation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68839335796083238216984cf69ffce3