### PR TITLE
Fix pre-assignment email to include all riders

### DIFF
--- a/assignments.html
+++ b/assignments.html
@@ -2046,7 +2046,11 @@ function sendPreNotify(riderName, evt) {
             hideLoading();
             showError('Error: ' + error.message);
         })
-        .sendPreAssignmentEmail(selectedRequest.id, riderName);
+        .sendPreAssignmentEmail(
+            selectedRequest.id,
+            riderName,
+            Array.from(selectedRiders)
+        );
 }
 
 


### PR DESCRIPTION
## Summary
- include list of all selected riders when pre-notifying from assignments page
- update NotificationService to accept rider list and build email using full rider information

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68839ce013c08323b9408cc0ad3d761b