### PR TITLE
Add rider details to executive summary

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -3198,6 +3198,24 @@ function generateExecutiveSummary(startDate, endDate) {
 
     totalHours = Math.round(totalHours * 100) / 100;
 
+    // Get rider activity within the same period
+    let riders = [];
+    try {
+      const startStr = Utilities.formatDate(start, CONFIG.system.timezone, 'yyyy-MM-dd');
+      const endStr = Utilities.formatDate(end, CONFIG.system.timezone, 'yyyy-MM-dd');
+      const riderReport = generateRiderActivityReport(startStr, endStr);
+      if (riderReport && riderReport.success && Array.isArray(riderReport.data)) {
+        riders = riderReport.data.map(r => ({
+          name: r.name,
+          escorts: r.escorts,
+          hours: r.hours,
+          average: r.escorts > 0 ? Math.round((r.hours / r.escorts) * 100) / 100 : 0
+        }));
+      }
+    } catch (riderErr) {
+      console.warn('Error generating rider activity for executive summary:', riderErr);
+    }
+
     return {
       success: true,
       data: {
@@ -3205,7 +3223,8 @@ function generateExecutiveSummary(startDate, endDate) {
         end: formatDateForDisplay(end),
         completedEscorts: completed,
         totalHours: totalHours,
-        requestTypes: typeMap
+        requestTypes: typeMap,
+        riders: riders
       }
     };
   } catch (error) {

--- a/reports.html
+++ b/reports.html
@@ -932,6 +932,14 @@ function displayRiderActivityReport(result) {
                 rows += '<tr><td>' + escapeHtml(t) + '</td><td>' + escapeHtml(types[t]) + '</td></tr>';
             }
 
+            var riderRows = '';
+            var riders = result.data.riders || [];
+            for (var i = 0; i < riders.length; i++) {
+                var r = riders[i];
+                riderRows += '<tr><td>' + escapeHtml(r.name) + '</td><td>' + escapeHtml(r.escorts) + '</td><td>' +
+                    escapeHtml(r.hours) + '</td><td>' + escapeHtml(r.average) + '</td></tr>';
+            }
+
             var html = '<!DOCTYPE html><html><head><title>Executive Summary</title>' +
                 '<style>body{font-family:Arial,sans-serif;padding:1rem;}table{border-collapse:collapse;width:100%;}' +
                 'th,td{border:1px solid #ccc;padding:.5rem;text-align:left;}th{background:#f4f4f4;}</style>' +
@@ -941,6 +949,9 @@ function displayRiderActivityReport(result) {
                 '<p>Total Hours: ' + escapeHtml(result.data.totalHours) + '</p>' +
                 '<h3>Request Type Distribution</h3>' +
                 '<table><thead><tr><th>Type</th><th>Count</th></tr></thead><tbody>' + rows + '</tbody></table>' +
+                '<h3>Rider Activity</h3>' +
+                '<table><thead><tr><th>Rider</th><th>Escorts</th><th>Hours</th><th>Avg/Escort</th></tr></thead><tbody>' +
+                riderRows + '</tbody></table>' +
                 '</body></html>';
 
             var reportWindow = window.open('', '_blank');


### PR DESCRIPTION
## Summary
- include rider activity metrics in `generateExecutiveSummary`
- display rider data in the executive summary report

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883e0d7c2208323ab9d1a045e4d3cba