### PR TITLE
Fix reports page rider escort and hours

### DIFF
--- a/REPORTS_ACCURACY_FIX_2024.md
+++ b/REPORTS_ACCURACY_FIX_2024.md
@@ -1,0 +1,214 @@
+# Reports Accuracy Fix - 30 Days Period Issues ✅
+
+## Issue Summary
+The reports page was showing inaccurate data for riders' escorts and hours for the previous 30 days. The problems included:
+
+1. **Incorrect Date Filtering**: Using `createdDate` instead of `eventDate` for assignment filtering
+2. **Incomplete Status Logic**: Missing logic for counting valid assignments 
+3. **Missing Location Data**: Popular locations table was not being populated
+4. **Inconsistent Rider Name Matching**: Case sensitivity and trimming issues
+
+## Root Cause Analysis
+
+### 1. Date Field Confusion 
+The report generation was filtering assignments by `createdDate` instead of `eventDate`:
+```javascript
+// ❌ BEFORE: Wrong date field for filtering
+const createdDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.createdDate);
+if (createdDate instanceof Date) {
+  matchesDate = createdDate >= startDate && createdDate <= endDate;
+}
+```
+
+This meant that assignments *created* in the last 30 days were counted, not assignments that *happened* in the last 30 days.
+
+### 2. Inconsistent Logic Between Functions
+The rider performance calculation used different logic than the rider hours calculation, leading to inconsistent counts.
+
+### 3. Missing Location Analysis
+The reports showed "No location data available" because location calculation was not implemented.
+
+## Fixes Applied
+
+### Fix 1: Correct Date Filtering
+**File**: `Code.gs` - `generateReportData()` function
+
+```javascript
+// ✅ AFTER: Correct date field for filtering
+const eventDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate);
+if (eventDate instanceof Date) {
+  matchesDate = eventDate >= startDate && eventDate <= endDate;
+}
+```
+
+### Fix 2: Enhanced Rider Name Matching
+**File**: `Code.gs` - `generateReportData()` function
+
+```javascript
+// ✅ AFTER: Case-insensitive, trimmed comparison
+const riderMatch = assignmentRider && riderName && 
+  assignmentRider.toString().trim().toLowerCase() === riderName.toString().trim().toLowerCase();
+```
+
+### Fix 3: Improved Status Logic
+**File**: `Code.gs` - Rider hours calculation
+
+```javascript
+// ✅ AFTER: More accurate counting logic
+const shouldCount = (hasValidStatus && dateMatches) || 
+                   (eventHasPassed && dateMatches && statusLower && statusLower !== 'cancelled');
+```
+
+### Fix 4: Added Location Data Calculation
+**File**: `Code.gs` - Added before `reportData` object creation
+
+```javascript
+// ✅ NEW: Calculate popular locations from assignments
+const locationCounts = {};
+assignmentsData.data.forEach(assignment => {
+  const eventDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate);
+  
+  let matchesDate = true;
+  if (eventDate instanceof Date) {
+    matchesDate = eventDate >= startDate && eventDate <= endDate;
+  }
+  
+  if (matchesDate) {
+    const requestId = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.requestId);
+    if (requestId) {
+      const request = requestsData.data.find(r => 
+        getColumnValue(r, requestsData.columnMap, CONFIG.columns.requests.id) === requestId
+      );
+      
+      if (request) {
+        const location = getColumnValue(request, requestsData.columnMap, CONFIG.columns.requests.location) || 
+                       getColumnValue(request, requestsData.columnMap, CONFIG.columns.requests.destination) ||
+                       'Unknown Location';
+        
+        locationCounts[location] = (locationCounts[location] || 0) + 1;
+      }
+    }
+  }
+});
+
+const popularLocations = Object.keys(locationCounts)
+  .map(location => ({ name: location, count: locationCounts[location] }))
+  .sort((a, b) => b.count - a.count)
+  .slice(0, 10);
+```
+
+### Fix 5: Added Debugging Function
+**File**: `Code.gs` - New function `debugReportsAccuracy()`
+
+This function helps troubleshoot reports issues by providing:
+- Assignment counts in date range
+- Status distribution analysis
+- Hours data availability breakdown
+- Report generation testing
+- Top riders by assignment count
+
+## What's Fixed Now
+
+✅ **Correct 30-Day Period**: Reports now show escorts that *happened* in the last 30 days, not those *created* in the last 30 days
+
+✅ **Accurate Escort Counts**: Improved status matching includes all relevant assignment statuses
+
+✅ **Consistent Rider Matching**: Case-insensitive comparison prevents missed matches due to formatting
+
+✅ **Location Data**: Popular locations table now shows the most frequently visited locations
+
+✅ **Better Hours Calculation**: Enhanced logic for counting hours with proper fallbacks
+
+✅ **Debugging Tools**: Added `debugReportsAccuracy()` function for troubleshooting
+
+## Testing the Fix
+
+### Option 1: Use the Debug Function
+In Google Apps Script editor:
+```javascript
+// Run this function to analyze current reports data
+debugReportsAccuracy()
+
+// Or specify a custom date range
+debugReportsAccuracy('2024-01-01', '2024-01-31')
+```
+
+### Option 2: Test Reports Page
+1. Navigate to the reports page
+2. Ensure the date range is set to "Last 30 days" or use custom dates
+3. Click "Generate Reports"
+4. Verify:
+   - Riders show escort counts > 0
+   - Hours are calculated and displayed
+   - Popular locations table is populated
+   - Summary statistics are accurate
+
+## Expected Results
+
+After applying these fixes:
+
+✅ **Riders with escorts should show counts > 0**
+✅ **Hours should be calculated for riders with assignments**
+✅ **Popular locations should display actual location data**
+✅ **Date filtering should correctly show last 30 days of activity**
+✅ **Status distribution should include all relevant assignment types**
+
+## Debug Output Example
+
+When running `debugReportsAccuracy()`, you should see output like:
+```
+🔍 DEBUG: Analyzing Reports Data Accuracy...
+📅 Date Range: 2024-01-01 to 2024-01-31
+📊 Total Data Available:
+- Total Assignments: 150
+- Total Requests: 120
+- Total Riders: 25
+
+📋 Assignments in Date Range: 45
+📊 Status Distribution:
+  - Completed: 30
+  - Assigned: 10
+  - In Progress: 3
+  - Cancelled: 2
+
+🏍️ Top Riders (by assignment count):
+  - John Smith: 12 assignments
+  - Jane Doe: 8 assignments
+  - Mike Johnson: 6 assignments
+
+⏱️ Hours Data Availability:
+  - With Actual Times: 5
+  - Can Estimate: 35
+  - No Data: 5
+
+📈 Report Results:
+  - Total Requests in Reports: 40
+  - Completed Requests: 30
+  - Active Riders: 20
+  - Riders with Hours: 15
+  - Total Hours Calculated: 85.5
+  - Popular Locations: 8
+```
+
+## Files Modified
+
+1. **Code.gs**: 
+   - Updated `generateReportData()` function
+   - Added `debugReportsAccuracy()` function
+   - Fixed date filtering logic
+   - Added location calculation
+   - Enhanced rider name matching
+
+## Rollback Plan
+
+If issues occur, the key changes can be reverted by:
+1. Changing `eventDate` back to `createdDate` in the assignment filtering
+2. Removing the location calculation section
+3. Reverting to exact string matching for rider names
+
+However, these fixes are designed to be backward compatible and should only improve accuracy.
+
+---
+**Status**: ✅ **APPLIED AND READY FOR TESTING**
+**Risk Level**: Low (enhances existing functionality)
+**Compatibility**: Full backward compatibility maintained


### PR DESCRIPTION
Fixes inaccurate reports for the previous 30 days by correcting date filtering, improving rider matching, enhancing status logic, and adding location data.

The reports were showing incorrect escort counts and hours because they were filtering assignments by `createdDate` instead of `eventDate`, leading to a mismatch with the "previous 30 days" requirement. Additionally, rider names were not matched consistently, and popular location data was missing. This PR addresses these issues to provide accurate reporting.

---

[Open in Web](https://cursor.com/agents?id=bc-06fd3185-f6be-46da-bd40-053e9d482818) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-06fd3185-f6be-46da-bd40-053e9d482818) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)