### PR TITLE
Color calendar days based on availability

### DIFF
--- a/enhanced-rider-availability.html
+++ b/enhanced-rider-availability.html
@@ -215,6 +215,25 @@
             transition: transform 0.1s ease;
         }
 
+        /* Calendar Day Cell Styling for Availability */
+        .fc-day.day-available {
+            background-color: #d4edda !important;
+            border-color: #27ae60 !important;
+        }
+
+        .fc-day.day-unavailable {
+            background-color: #f8d7da !important;
+            border-color: #e74c3c !important;
+        }
+
+        .fc-day.day-available:hover {
+            background-color: #c3e6cb !important;
+        }
+
+        .fc-day.day-unavailable:hover {
+            background-color: #f1b0b7 !important;
+        }
+
         /* Voice Input Interface */
         .voice-interface {
             position: fixed;
@@ -577,6 +596,7 @@
         let speechRecognition;
         let isVoiceActive = false;
         let fabMenuOpen = false;
+        let availabilityByDate = {}; // Store availability status by date for day cell coloring
         let gestureHints = [
             "👆 Swipe days to update",
             "🎤 Long press for voice",
@@ -760,10 +780,12 @@
             google.script.run
                 .withSuccessHandler(function(events) {
                     console.log('Raw events from backend:', events);
+                    
+                    // Clear existing events and availability tracking
+                    calendar.removeAllEvents();
+                    availabilityByDate = {};
+                    
                     if (events && events.length > 0) {
-                        // Clear existing events
-                        calendar.removeAllEvents();
-                        
                         // Add events to calendar with proper styling
                         events.forEach((event, index) => {
                             const statusColors = {
@@ -783,7 +805,28 @@
                             
                             console.log(`Adding event ${index + 1}:`, eventWithColors);
                             calendar.addEvent(eventWithColors);
+                            
+                            // Track availability by date for day cell coloring
+                            const eventStart = new Date(event.start);
+                            const eventEnd = new Date(event.end || event.start);
+                            
+                            // Handle multi-day events or single day events
+                            let currentDate = new Date(eventStart);
+                            while (currentDate <= eventEnd) {
+                                const dateStr = currentDate.toISOString().split('T')[0];
+                                
+                                // If multiple events on same day, prioritize available over unavailable
+                                if (!availabilityByDate[dateStr] || 
+                                    (availabilityByDate[dateStr] === 'unavailable' && event.status === 'available')) {
+                                    availabilityByDate[dateStr] = event.status;
+                                }
+                                
+                                currentDate.setDate(currentDate.getDate() + 1);
+                            }
                         });
+                        
+                        // Refresh calendar to apply day cell styling
+                        calendar.render();
                         
                         console.log('✅ Loaded', events.length, 'availability events');
                         showNotification(`📅 Loaded ${events.length} availability entries`, 'success');
@@ -796,6 +839,11 @@
                     console.error('Error loading availability data:', error);
                 })
                 .getUserAvailabilityForCalendar(currentUser.email);
+        }
+
+        // Get availability status for a specific date
+        function getDayAvailabilityStatus(dateStr) {
+            return availabilityByDate[dateStr] || null;
         }
 
         function setupGestureHints() {
@@ -892,6 +940,18 @@
                 dayCellDidMount: function(info) {
                     // Add gesture support to each day cell
                     setupDayGestures(info.el, info.date);
+                },
+                
+                dayCellClassNames: function(info) {
+                    const dateStr = info.date.toISOString().split('T')[0];
+                    const dayStatus = getDayAvailabilityStatus(dateStr);
+                    
+                    if (dayStatus === 'available') {
+                        return ['day-available'];
+                    } else if (dayStatus === 'unavailable') {
+                        return ['day-unavailable'];
+                    }
+                    return [];
                 }
             });
 

--- a/rider-availability.html
+++ b/rider-availability.html
@@ -392,6 +392,25 @@
             color: white !important;
         }
 
+        /* Calendar Day Cell Styling for Availability */
+        .fc-day.day-available {
+            background-color: #d4edda !important;
+            border-color: #27ae60 !important;
+        }
+
+        .fc-day.day-unavailable {
+            background-color: #f8d7da !important;
+            border-color: #e74c3c !important;
+        }
+
+        .fc-day.day-available:hover {
+            background-color: #c3e6cb !important;
+        }
+
+        .fc-day.day-unavailable:hover {
+            background-color: #f1b0b7 !important;
+        }
+
         /* Loading States */
         .loading-state {
             text-align: center;
@@ -705,6 +724,7 @@
         let allRidersData = [];
         let selectedRiders = [];
         let editingEvent = null;
+        let availabilityByDate = {}; // Store availability status by date for day cell coloring
 
         // Initialize application
         document.addEventListener('DOMContentLoaded', function() {
@@ -784,6 +804,17 @@
                     if (status) {
                         info.el.classList.add(status);
                     }
+                },
+                dayCellClassNames: function(info) {
+                    const dateStr = info.date.toISOString().split('T')[0];
+                    const dayStatus = getDayAvailabilityStatus(dateStr);
+                    
+                    if (dayStatus === 'available') {
+                        return ['day-available'];
+                    } else if (dayStatus === 'unavailable') {
+                        return ['day-unavailable'];
+                    }
+                    return [];
                 }
             });
 
@@ -857,7 +888,10 @@
 
         function handleMyAvailabilityLoaded(events) {
             riderCalendar.removeAllEvents();
+            availabilityByDate = {}; // Reset availability tracking
+            
             events.forEach(event => {
+                // Add event to calendar
                 riderCalendar.addEvent({
                     id: event.id,
                     title: event.title || getStatusTitle(event.status),
@@ -869,7 +903,33 @@
                         riderId: event.riderId
                     }
                 });
+                
+                // Track availability by date for day cell coloring
+                const eventStart = new Date(event.start);
+                const eventEnd = new Date(event.end);
+                
+                // Handle multi-day events or single day events
+                let currentDate = new Date(eventStart);
+                while (currentDate <= eventEnd) {
+                    const dateStr = currentDate.toISOString().split('T')[0];
+                    
+                    // If multiple events on same day, prioritize available over unavailable
+                    if (!availabilityByDate[dateStr] || 
+                        (availabilityByDate[dateStr] === 'unavailable' && event.status === 'available')) {
+                        availabilityByDate[dateStr] = event.status;
+                    }
+                    
+                    currentDate.setDate(currentDate.getDate() + 1);
+                }
             });
+            
+            // Refresh calendar to apply day cell styling
+            riderCalendar.render();
+        }
+
+        // Get availability status for a specific date
+        function getDayAvailabilityStatus(dateStr) {
+            return availabilityByDate[dateStr] || null;
         }
 
         // Load all riders data (admin view)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add visual coloring to calendar days to show available days in green and unavailable days in red.

---

[Open in Web](https://cursor.com/agents?id=bc-237b9a53-6fbc-48f2-b563-dcbda17fd562) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-237b9a53-6fbc-48f2-b563-dcbda17fd562) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)