### PR TITLE
Investigate report calculation discrepancy

### DIFF
--- a/REPORTS_DISCREPANCY_FIX_SUMMARY.md
+++ b/REPORTS_DISCREPANCY_FIX_SUMMARY.md
@@ -1,0 +1,150 @@
+# Reports Discrepancy Fix Summary
+
+## Problem Statement
+The reports page showed **79 completed requests** but the rider activity section only displayed **28 entries**, creating confusion about actual system performance and rider workload.
+
+## Root Cause Analysis
+
+### The Issue
+Two different calculations were using **different data sources and logic**:
+
+#### 1. **Report "Completed Requests" (79 entries)**
+- **Data Source**: `requests` table
+- **Logic**: `status === 'Completed'`
+- **Location**: `generateReportData()` function in `Code.gs` lines 2692-2694
+- **Problem**: Counted all requests marked "Completed" regardless of whether they had corresponding assignments
+
+#### 2. **Rider Activity Entries (28 entries)**  
+- **Data Source**: `assignments` table
+- **Logic**: Much more restrictive - only counted assignments where:
+  - Assignment status is `'completed'` OR
+  - Event date has passed AND assignment was in working status (`'assigned', 'confirmed', 'en route', 'in progress'`)
+- **Location**: `generateRiderActivityReport()` function in `Code.gs` lines 3240-3245
+- **Behavior**: Only counted assignments where riders actually performed work
+
+### Why the Discrepancy Occurred
+
+1. **Orphaned Completed Requests**: Some requests were marked "Completed" without corresponding assignment records
+2. **Incomplete Workflow**: Requests could be completed without proper assignment tracking
+3. **External Completions**: Some requests may have been completed by external riders not tracked in assignments
+4. **Data Entry Issues**: Manual status updates bypassing the assignment workflow
+
+## Solution Implemented
+
+### Fix Applied
+Updated the `generateReportData()` function in `Code.gs` to use **assignment-based counting** for the "Completed Requests" metric, making it consistent with the rider activity calculation.
+
+**Before (Request-based):**
+```javascript
+const completedRequests = filteredRequests.filter(request => 
+  getColumnValue(request, requestsData.columnMap, CONFIG.columns.requests.status) === 'Completed'
+).length;
+```
+
+**After (Assignment-based):**
+```javascript
+// FIXED: Use assignment-based counting for consistency with rider activity
+let completedRequests = 0;
+assignmentsData.data.forEach(assignment => {
+  const eventDate = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.eventDate);
+  
+  // Apply same date filter as filteredRequests
+  let dateMatches = true;
+  if (eventDate instanceof Date) {
+    dateMatches = eventDate >= startDate && eventDate <= endDate;
+  }
+  if (!dateMatches) return;
+  
+  const status = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.status);
+  const rider = getColumnValue(assignment, assignmentsData.columnMap, CONFIG.columns.assignments.riderName);
+  
+  if (!rider) return;
+
+  // Apply same logic as generateRiderActivityReport for consistency
+  const statusLower = (status || '').toLowerCase().trim();
+  const eventDateObj = eventDate instanceof Date ? eventDate : new Date(eventDate);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  
+  const isCompleted = statusLower === 'completed';
+  const eventHasPassed = !isNaN(eventDateObj.getTime()) && eventDateObj < today;
+  const wasAssigned = ['assigned', 'confirmed', 'en route', 'in progress'].includes(statusLower);
+  
+  if (isCompleted || (eventHasPassed && wasAssigned)) {
+    completedRequests++;
+  }
+});
+```
+
+## Expected Results After Fix
+
+✅ **Consistent Numbers**: Both "Completed Requests" and "Rider Activity" will now show the same count (28 entries)
+
+✅ **Accurate Reporting**: Numbers reflect actual work performed by riders, not just request status changes
+
+✅ **Better Data Integrity**: Reports now align with the assignment workflow
+
+## Impact of the Change
+
+### What Changed
+- **"Completed Requests" metric** now reflects actual rider assignments worked, not just request status
+- **Numbers will be lower** but more accurate (from 79 to 28 in the current case)
+
+### What Stayed the Same
+- Rider activity calculation logic (unchanged)
+- All other report metrics and charts
+- Data entry workflows
+
+## Files Modified
+
+1. **`Code.gs`** - Updated `generateReportData()` function (lines ~2692-2694)
+2. **`reports_discrepancy_diagnostic.gs`** - Added diagnostic script for future troubleshooting
+
+## Diagnostic Tools Added
+
+### `analyzeReportsDiscrepancy(startDate, endDate)`
+Comprehensive diagnostic function that:
+- Compares both calculation methods
+- Identifies orphaned requests
+- Shows status distributions  
+- Provides detailed cross-reference analysis
+- Gives recommendations for data cleanup
+
+**Usage:**
+```javascript
+// Run in Apps Script editor
+analyzeReportsDiscrepancy('2024-01-01', '2024-01-31');
+```
+
+## Prevention Measures
+
+### Immediate Recommendations
+1. **Data Cleanup**: Review and create assignments for orphaned completed requests
+2. **Workflow Training**: Ensure all requests follow proper assignment workflow
+3. **Validation Rules**: Add data validation to prevent request completion without assignments
+
+### Long-term Improvements
+1. **Unified Data Model**: Consider consolidating request and assignment tracking
+2. **Automated Assignment Creation**: Auto-create assignments when riders are assigned to requests
+3. **Status Synchronization**: Keep request and assignment statuses in sync
+4. **Regular Audits**: Run the diagnostic script monthly to catch discrepancies early
+
+## Testing the Fix
+
+After deployment:
+1. ✅ Generate reports and verify consistent numbers between "Completed Requests" and "Rider Activity"
+2. ✅ Test with different date ranges to ensure fix works across all time periods
+3. ✅ Run diagnostic script to verify no new discrepancies
+4. ✅ Confirm all other report metrics still function correctly
+
+## Related Documentation
+
+- **Original Analysis**: `reports_analysis_and_fix.md`
+- **Diagnostic Script**: `reports_discrepancy_diagnostic.gs`
+- **Configuration**: `CONFIG.columns.assignments` and `CONFIG.columns.requests`
+
+---
+
+**Fix Status**: ✅ **COMPLETED**  
+**Date Applied**: Current Session  
+**Validation**: Pending deployment testing


### PR DESCRIPTION
Align 'Completed Requests' report metric with 'Rider Activity' by using assignment-based counting to resolve data discrepancy.

The previous calculation for 'Completed Requests' in the main report counted requests marked 'Completed' from the `requests` table, which often included requests without corresponding rider assignments. This led to a significant discrepancy with 'Rider Activity', which accurately counted completed assignments where riders performed work. This PR updates the 'Completed Requests' calculation to use the same assignment-based logic, ensuring consistency and accuracy in reporting actual rider work.

---

[Open in Web](https://cursor.com/agents?id=bc-2b8f1a66-9991-4c6a-a84c-3b32299dfa89) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2b8f1a66-9991-4c6a-a84c-3b32299dfa89) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)