### PR TITLE
Count only completed requests for stats

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2683,11 +2683,11 @@ function generateReportData(filters) {
       return matchesDate && matchesType && matchesStatus;
     });
     
-    // Calculate summary statistics
-    const totalRequests = filteredRequests.length;
+    // Calculate summary statistics - only count completed requests, not assignments
     const completedRequests = filteredRequests.filter(request => 
       getColumnValue(request, requestsData.columnMap, CONFIG.columns.requests.status) === 'Completed'
     ).length;
+    const totalRequests = completedRequests; // Only count completed requests as specified
     
     const activeRiders = ridersData.data.filter(rider =>
       getColumnValue(rider, ridersData.columnMap, CONFIG.columns.riders.status) === 'Active'


### PR DESCRIPTION
Modify report statistics to count only completed requests, excluding assignments from the total.

---

[Open in Web](https://cursor.com/agents?id=bc-4d1cd1a9-aacd-44e1-b701-b4a490f28a7e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4d1cd1a9-aacd-44e1-b701-b4a490f28a7e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)