### PR TITLE
Fix null data fallback on riders page

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -775,7 +775,8 @@
                     // Additional validation
                     if (!data) {
                         console.error('❌ Received null/undefined data from backend');
-                        handleRidersDataFailure({ message: "No data received from server" });
+                        // Attempt fallbacks before showing an error
+                        tryFallbackDataLoading(new Error('No data received from server'));
                         return;
                     }
                     


### PR DESCRIPTION
## Summary
- handle null data by running fallback loader for riders page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887c0dbbf188323b7f9242369444a74