### PR TITLE
Fix undefined error debuglog on main page

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -3860,6 +3860,34 @@ function getColumnValue(row, columnMap, columnName) {
 }
 
 /**
+ * Debug logging function that respects configuration settings
+ * @param {...any} args - Arguments to log
+ */
+function debugLog(...args) {
+  // Check if debug logging is enabled in CONFIG
+  if (CONFIG.performance && CONFIG.performance.enableDebugLogging) {
+    console.log('[DEBUG]', ...args);
+  } else if (CONFIG.system && CONFIG.system.enableDebugLogging) {
+    console.log('[DEBUG]', ...args);
+  }
+  // If debugging is disabled, this function does nothing (silent)
+}
+
+/**
+ * Test function to validate debugLog functionality
+ * Run this function in the Apps Script editor to test if debugLog works
+ */
+function testDebugLog() {
+  console.log('Testing debugLog function...');
+  debugLog('This is a test debug message');
+  debugLog('Debug logging status:', 
+    'performance.enableDebugLogging:', CONFIG.performance?.enableDebugLogging,
+    'system.enableDebugLogging:', CONFIG.system?.enableDebugLogging
+  );
+  console.log('debugLog test completed. Check console output above.');
+}
+
+/**
  * Log error safely
  */
 function logError(message, error) {

--- a/README_DEBUG_SETUP.md
+++ b/README_DEBUG_SETUP.md
@@ -1,0 +1,62 @@
+# Debug Logging Setup - Motorcycle Escort Management System
+
+## Issue Resolved: "debuglog is not defined" Error
+
+### Problem
+The application was calling `debugLog()` throughout the codebase but the function was never defined, causing runtime errors.
+
+### Solution
+Added the missing `debugLog()` function to `Code.gs` that respects the configuration settings.
+
+### Debug Logging Function
+```javascript
+function debugLog(...args) {
+  // Check if debug logging is enabled in CONFIG
+  if (CONFIG.performance && CONFIG.performance.enableDebugLogging) {
+    console.log('[DEBUG]', ...args);
+  } else if (CONFIG.system && CONFIG.system.enableDebugLogging) {
+    console.log('[DEBUG]', ...args);
+  }
+  // If debugging is disabled, this function does nothing (silent)
+}
+```
+
+### How to Enable Debug Logging
+
+#### Method 1: Enable via Performance Settings
+In `Config.gs`, change:
+```javascript
+performance: {
+  enableDebugLogging: true,  // Change from false to true
+  // ... other settings
+}
+```
+
+#### Method 2: Enable via System Settings
+In `Config.gs`, change:
+```javascript
+system: {
+  enableDebugLogging: true,  // Change from false to true
+  // ... other settings
+}
+```
+
+### Testing Debug Logging
+Run the `testDebugLog()` function in the Google Apps Script editor to verify the debug logging is working correctly.
+
+### Production Considerations
+- Debug logging is disabled by default for performance reasons
+- Only enable debug logging temporarily for troubleshooting
+- Remember to disable it again in production environments
+
+### Files Modified
+- `Code.gs` - Added `debugLog()` function and `testDebugLog()` function
+- This README file created for documentation
+
+### Usage
+The `debugLog()` function can now be called from anywhere in the codebase:
+```javascript
+debugLog('This is a debug message');
+debugLog('User logged in:', userEmail);
+debugLog('Processing request:', requestData);
+```


### PR DESCRIPTION
Add missing `debugLog` function and documentation to resolve "debuglog is not defined" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-585dcb8b-a698-48b2-b93c-01c520a2e954">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-585dcb8b-a698-48b2-b93c-01c520a2e954">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>