### PR TITLE
Fix dropoff field order on add new requests page

### DIFF
--- a/requests.html
+++ b/requests.html
@@ -710,13 +710,13 @@
                             </div>
                             
                             <div class="form-group">
-                                <label for="editEndLocation">Dropoff</label>
-                                <input type="text" id="editEndLocation" />
+                                <label for="editSecondaryLocation">Dropoff *</label>
+                                <input type="text" id="editSecondaryLocation" required />
                             </div>
 
                             <div class="form-group">
-                                <label for="editSecondaryLocation">Second *</label>
-                                <input type="text" id="editSecondaryLocation" required />
+                                <label for="editEndLocation">Second</label>
+                                <input type="text" id="editEndLocation" />
                             </div>
                             
                             <div class="form-group">


### PR DESCRIPTION
## Summary
- swap dropoff and second location fields on request form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888335068e48323aea8ec5d12394191