### PR TITLE
Move NOPD entry to bottom of reports

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2890,8 +2890,16 @@ function generateReportData(filters) {
         monthlyTrends: {}
       },
       tables: {
-        riderPerformance: riderPerformance.sort((a, b) => b.assignments - a.assignments),
-        riderHours: riderHours.sort((a, b) => b.escorts - a.escorts),
+        riderPerformance: riderPerformance.sort((a, b) => {
+          if (a.name === 'NOPD') return 1;
+          if (b.name === 'NOPD') return -1;
+          return b.assignments - a.assignments;
+        }),
+        riderHours: riderHours.sort((a, b) => {
+          if (a.name === 'NOPD') return 1;
+          if (b.name === 'NOPD') return -1;
+          return b.escorts - a.escorts;
+        }),
         locations: popularLocations,
         responseTime: {}
       }
@@ -3321,7 +3329,11 @@ function generateRiderActivityReport(startDate, endDate) {
       });
     });
     
-    const data = filteredData.sort((a, b) => b.escorts - a.escorts);
+    const data = filteredData.sort((a, b) => {
+      if (a.name === 'NOPD') return 1;
+      if (b.name === 'NOPD') return -1;
+      return b.escorts - a.escorts;
+    });
 
   return { success: true, data };
   } catch (error) {

--- a/NOPD_RIDER_AVAILABILITY_IMPLEMENTATION.md
+++ b/NOPD_RIDER_AVAILABILITY_IMPLEMENTATION.md
@@ -90,3 +90,4 @@ This implementation adds support for NOPD (New Orleans Police Department) riders
 - Could add more organization types with different availability rules
 - Could add organization-specific rider assignment preferences
 - Could implement organization-based reporting and analytics
+- Reports list the consolidated NOPD entry last to keep focus on other riders


### PR DESCRIPTION
## Summary
- sort `riderPerformance` and `riderHours` tables so NOPD is last
- apply same ordering in `generateRiderActivityReport`
- document this behaviour in NOPD rider guide

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c1858b7588323963f9c3362ebef01