### PR TITLE
fix: handle missing report filters

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -4165,6 +4165,15 @@ function getPageDataForReports(filters) {
   try {
     debugLog('🔄 Loading reports page data...', filters);
 
+    // Ensure filters is a usable object with default values
+    const safeFilters = {
+      startDate: '',
+      endDate: '',
+      requestType: '',
+      status: '',
+      ...(typeof filters === 'object' && filters !== null ? filters : {})
+    };
+
     // Create a default user without authentication
     const defaultUser = {
       name: 'System User',
@@ -4174,21 +4183,21 @@ function getPageDataForReports(filters) {
     };
 
     // Generate report data directly without authentication checks
-    const reportData = generateReportData(filters);
-    
-    return { 
-      success: true, 
-      user: defaultUser, 
-      reportData: reportData 
+    const reportData = generateReportData(safeFilters);
+
+    return {
+      success: true,
+      user: defaultUser,
+      reportData: reportData
     };
-    
+
   } catch (error) {
     console.error('Error in getPageDataForReports:', error);
-    return { 
-      success: false, 
-      error: error.message, 
-      user: { name: 'System User' }, 
-      reportData: null 
+    return {
+      success: false,
+      error: error.message,
+      user: { name: 'System User' },
+      reportData: null
     };
   }
 }


### PR DESCRIPTION
## Summary
- ensure report data generation receives safe default filters when none are provided
- avoid crashing reports page by sanitizing filters

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688fa951b4b883239749cfd00a951352