### PR TITLE
Fix rider activity average formula

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -5119,7 +5119,7 @@ function exportRiderActivityCSV(startDate, endDate) {
     const csvRows = [headers.join(',')];
     report.data.forEach(r => {
       const requests = r.requests !== undefined ? r.requests : r.escorts;
-      const avg = r.hours > 0 ? Math.round((requests / r.hours) * 4) / 4 : 0;
+      const avg = requests > 0 ? Math.round((r.hours / requests) * 4) / 4 : 0;
       const row = [
         `"${String(r.name).replace(/"/g, '""')}"`,
         requests,

--- a/reports.html
+++ b/reports.html
@@ -978,7 +978,7 @@ function updateTablesSafe(tables) {
                 tableHtml += '<tr>';
                 var requests = (rider.requests !== undefined) ? rider.requests : (rider.escorts || 0);
                 var hours = rider.hours || 0;
-                var avg = hours > 0 ? Math.round((requests / hours) * 4) / 4 : 0;
+                var avg = requests > 0 ? Math.round((hours / requests) * 4) / 4 : 0;
                 tableHtml += '<td>' + escapeHtml(rider.name || rider.riderName || rider.rider || 'Unknown') + '</td>';
                 tableHtml += '<td>' + requests + '</td>';
                 tableHtml += '<td>' + hours + '</td>';
@@ -1089,7 +1089,7 @@ function updateTablesSafe(tables) {
                     var r = data[i];
                     var requests = (r.requests !== undefined) ? r.requests : (r.escorts !== undefined ? r.escorts : 0);
                     var hours = (r.hours !== undefined) ? r.hours : 0;
-                    var avg = hours > 0 ? Math.round((requests / hours) * 4) / 4 : 0;
+                    var avg = requests > 0 ? Math.round((hours / requests) * 4) / 4 : 0;
                     hoursRows += '<tr><td>' + escapeHtml(r.name || r.riderName || '') + '</td><td>' + requests + '</td><td>' + hours + '</td><td>' + avg.toFixed(2) + '</td></tr>';
                 }
                 if (data.length === 0) {
@@ -1215,7 +1215,7 @@ function displayRiderActivityReport(result) {
                 var r = data[i];
                 var requests = (r.requests !== undefined) ? r.requests : (r.escorts || 0);
                 var hours = r.hours || 0;
-                var avg = hours > 0 ? Math.round((requests / hours) * 4) / 4 : 0;
+                var avg = requests > 0 ? Math.round((hours / requests) * 4) / 4 : 0;
                 rows += '<tr><td>' + escapeHtml(r.name || r.riderName || '') + '</td><td>' + escapeHtml(requests) + '</td><td>' + escapeHtml(hours) + '</td><td>' + avg.toFixed(2) + '</td></tr>';
             }
 


### PR DESCRIPTION
## Summary
- compute rider activity average as hours per request
- apply new average calculation to reports page and CSV export

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890f29ecc9c8323ba40af9f802c508d