### PR TITLE
Count only upcoming assignments on dashboard

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -2074,11 +2074,19 @@ function getDashboardDataForUser(user) {
       
     } else if (user.role === 'rider') {
       const myAssignments = getAssignmentsForRider(user.riderId);
+      const today = new Date();
+      const upcomingAssignments = myAssignments.filter(a => {
+        try {
+          return new Date(a.eventDate) >= today;
+        } catch (e) {
+          return false;
+        }
+      });
       dashboardData.stats = {
-        myAssignments: myAssignments.length,
-        pendingAssignments: myAssignments.filter(a => a.status === 'Pending').length,
-        completedThisMonth: myAssignments.filter(a => 
-          a.status === 'Completed' && 
+        myAssignments: upcomingAssignments.length,
+        pendingAssignments: upcomingAssignments.filter(a => a.status === 'Pending').length,
+        completedThisMonth: myAssignments.filter(a =>
+          a.status === 'Completed' &&
           isThisMonth(a.completionDate)
         ).length,
         nextEscort: getNextEscortForRider(user.riderId)

--- a/AppServices.gs
+++ b/AppServices.gs
@@ -2906,6 +2906,15 @@ function getPageDataForDashboard(user) { // Added user parameter
       }
     }
     const upcomingAssignments = getUpcomingAssignmentsForWebApp(user);
+    const today = new Date().toDateString();
+    stats.todayAssignments = upcomingAssignments.filter(a => {
+      try {
+        return new Date(a.eventDate).toDateString() === today;
+      } catch (e) {
+        return false;
+      }
+    }).length;
+    stats.weekAssignments = upcomingAssignments.length;
     return { success: true, user, stats, recentRequests, upcomingAssignments };
   } catch (error) {
     logError('Error in getPageDataForDashboard', error);


### PR DESCRIPTION
## Summary
- Display only upcoming rider assignments in dashboard stats
- Base assignment counters on upcoming assignments, including today and week summaries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892b61240248323998d8255a0334949