### PR TITLE
fix: include final day in public assignment summary

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -5190,8 +5190,10 @@ function exportPublicAssignmentSummaryCSV(startDate) {
     const year = start.getFullYear();
     const month = start.getMonth();
     const firstDay = new Date(year, month, 1);
+    firstDay.setHours(0, 0, 0, 0);
     const lastDay = new Date(year, month + 1, 0);
     const daysInMonth = lastDay.getDate();
+    lastDay.setHours(23, 59, 59, 999);
     const timezone = (CONFIG.system && CONFIG.system.timezone) || Session.getScriptTimeZone();
 
     const ridersData = getRidersData();


### PR DESCRIPTION
## Summary
- ensure public assignment summaries include assignments from the last day of the month

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894a8431b88832387cbb30d83ff1fbd