### PR TITLE
Move public assignment summary button to filter controls

### DIFF
--- a/reports.html
+++ b/reports.html
@@ -468,8 +468,8 @@
                     📊 Generate Reports
                 </button>
                 
-                <button class="btn btn-success" onclick="showCurrentFilters()" style="margin-left: 0.5rem;">
-                    📋 Show Filters
+                <button class="btn btn-success" onclick="exportPublicAssignmentSummary()" style="margin-left: 0.5rem;">
+                    📥 Public Assignment Summary
                 </button>
             </div>
 
@@ -564,11 +564,6 @@
         </div>
     </div>
 
-    <div class="export-section" style="text-align: center; margin: 2rem 0;">
-        <button class="btn btn-success" onclick="exportPublicAssignmentSummary()">
-            📥 Public Assignment Summary
-        </button>
-    </div>
 
     <div id="riderRequestsModal">
         <div class="modal-content">


### PR DESCRIPTION
## Summary
- place the Public Assignment Summary export button alongside report filters
- remove the obsolete Show Filters and export section buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac4be1c08323b882568c20ab1b35