### PR TITLE
Fix riders page data loading

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -758,10 +758,11 @@
         showLoading();
         
         if (typeof google !== 'undefined' && google.script && google.script.run) {
+            // Use secured page data API to ensure full response structure
             google.script.run
                 .withSuccessHandler(handleRidersDataSuccess)
                 .withFailureHandler(handleRidersDataFailure)
-                .getPageDataForRiders();
+                .getSecuredPageData('riders');
         } else {
             console.log('⚠️ Google Apps Script not available');
             handleRidersDataFailure({ message: "Google Apps Script not available." });


### PR DESCRIPTION
## Summary
- Use `getSecuredPageData('riders')` when loading the riders list to ensure a full response structure

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6894f3210f40832399605bf7e561d876