### PR TITLE
Fix riders page data loading

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -758,11 +758,11 @@
         showLoading();
         
         if (typeof google !== 'undefined' && google.script && google.script.run) {
-            // Use secured page data API to ensure full response structure
+            // Directly fetch riders page data from backend
             google.script.run
                 .withSuccessHandler(handleRidersDataSuccess)
                 .withFailureHandler(handleRidersDataFailure)
-                .getSecuredPageData('riders');
+                .getPageDataForRiders();
         } else {
             console.log('⚠️ Google Apps Script not available');
             handleRidersDataFailure({ message: "Google Apps Script not available." });


### PR DESCRIPTION
## Summary
- Switch riders page to call backend `getPageDataForRiders` directly for proper data retrieval

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68964c82d7ac8323aaa3ef20f17c4cb2