### PR TITLE
fix: allow legacy calls to getUserAvailability

### DIFF
--- a/AppServices.gs
+++ b/AppServices.gs
@@ -5426,12 +5426,23 @@ function saveUserAvailability(userOrEntry, entry) { // Added user parameter
 /**
  * Retrieve availability entries for the specified email or current user.
  * @param {string} [email] Optional email address. Defaults to current user.
+ * Supports legacy calls like getUserAvailability(email) or getUserAvailability().
  * @return {Array<object>} Array of availability objects.
  */
-function getUserAvailability(user, email) { // Added user parameter
+function getUserAvailability(userOrEmail, email) {
   try {
-    // const user = getCurrentUser(); // Removed: user is now a parameter
-    const targetEmail = email || user.email;
+    let targetEmail;
+
+    if (arguments.length === 2) {
+      targetEmail = email || (userOrEmail && userOrEmail.email);
+    } else if (arguments.length === 1) {
+      targetEmail = (typeof userOrEmail === 'string')
+        ? userOrEmail
+        : (userOrEmail && userOrEmail.email);
+    }
+    if (!targetEmail) {
+      targetEmail = getCurrentUser().email;
+    }
 
     const sheetData = getSheetData(CONFIG.sheets.availability, true);
     const map = sheetData.columnMap;


### PR DESCRIPTION
## Summary
- ensure `getUserAvailability` handles legacy calls without a user object or with a plain email
- avoid missing availability results for admin management page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a731f005c8323a49ecad10c04dd01