### PR TITLE
Fix links for rider edit and availability pages

### DIFF
--- a/_navigation.html
+++ b/_navigation.html
@@ -3,7 +3,7 @@
     <a href="requests.html" class="nav-button" id="nav-requests" data-page="requests" target="_top">📋 Requests</a>
     <a href="assignments.html" class="nav-button" id="nav-assignments" data-page="assignments" target="_top">🏍️ Assignments</a>
     <a href="riders.html" class="nav-button" id="nav-riders" data-page="riders" target="_top">👥 Riders</a>
-    <a href="enhanced-rider-availability.html" class="nav-button" id="nav-availability" data-page="availability" target="_top">🗓️ Availability</a>
+    <a href="enhanced-rider-availability.html" class="nav-button" id="nav-availability" data-page="enhanced-rider-availability" target="_top">🗓️ Availability</a>
     <a href="notifications.html" class="nav-button" id="nav-notifications" data-page="notifications" target="_top">📱 Notifications</a>
     <a href="reports.html" class="nav-button" id="nav-reports" data-page="reports" target="_top">📊 Reports</a>
 </nav>

--- a/riders.html
+++ b/riders.html
@@ -80,7 +80,7 @@
         riders.forEach(r => {
           const tr = document.createElement('tr');
           const id = r.jpNumber || '';
-          const nameCell = `<a href="edit-rider.html?riderId=${id}">${r.name || ''}</a>`;
+          const nameCell = `<a href="?page=edit-rider&riderId=${encodeURIComponent(id)}">${r.name || ''}</a>`;
           const availabilityBtn = `<button onclick="openAvailability('${id}')">Calendar</button>`;
           tr.innerHTML = `<td>${id}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
           tbody.appendChild(tr);
@@ -96,7 +96,7 @@
     }
 
       function openAvailability(riderId) {
-        window.open(`rider-availability.html?riderId=${encodeURIComponent(riderId)}`, '_blank');
+        window.open(`?page=rider-availability&riderId=${encodeURIComponent(riderId)}`, '_blank');
       }
 
       function loadRiders() {


### PR DESCRIPTION
## Summary
- Correct navigation entry for availability to point to existing enhanced calendar page
- Use `?page=` query links for rider editing and availability to avoid missing pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b855c01a88323a3ada80f79a2c056