### PR TITLE
Fix availability calendar saving and day shading

### DIFF
--- a/AvailabilityService.gs
+++ b/AvailabilityService.gs
@@ -210,13 +210,29 @@ function saveRiderAvailabilityData(data) {
     // Determine rider ID
     const riderId = data.riderId || currentUser.riderId || getUserRiderId(currentUser.email);
 
-    // Prepare row data
+    // Track timestamps
+    const timestamp = new Date();
+    let createdDate = timestamp;
+
+    // Check if updating existing entry to preserve original created date
+    if (data.id && data.id.startsWith('avail_')) {
+      const rowIndex = parseInt(data.id.replace('avail_', ''));
+      if (rowIndex >= 0 && rowIndex < sheetData.data.length) {
+        const existingRow = sheetData.data[rowIndex];
+        createdDate = getColumnValue(existingRow, sheetData.columnMap, CONFIG.columns.availability.created) || timestamp;
+      }
+    }
+
+    // Prepare row data matching sheet columns
     const rowData = [
       currentUser.email,
       new Date(data.date),
       data.startTime,
       data.endTime,
-      generateAvailabilityNotes(data.status, data.notes),
+      data.status || 'available',
+      data.notes || '',
+      createdDate,
+      timestamp,
       riderId
     ];
 

--- a/rider-availability.html
+++ b/rider-availability.html
@@ -392,6 +392,15 @@
             color: white !important;
         }
 
+        /* Background shading for day availability */
+        .fc-bg-event.available-bg {
+            background: rgba(39, 174, 96, 0.2);
+        }
+
+        .fc-bg-event.unavailable-bg {
+            background: rgba(231, 76, 60, 0.2);
+        }
+
         /* Loading States */
         .loading-state {
             text-align: center;
@@ -873,6 +882,19 @@
                         notes: event.notes,
                         riderId: event.riderId
                     }
+                });
+
+                // Shade day cell based on availability status
+                const startDate = new Date(event.start);
+                const dayStart = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+                const dayEnd = new Date(dayStart);
+                dayEnd.setDate(dayEnd.getDate() + 1);
+
+                riderCalendar.addEvent({
+                    start: dayStart,
+                    end: dayEnd,
+                    display: 'background',
+                    classNames: [event.status === 'available' ? 'available-bg' : 'unavailable-bg']
                 });
             });
         }


### PR DESCRIPTION
## Summary
- Correct availability saving routine to include status, notes, timestamps, and rider ID so entries persist in backend sheet.
- Add CSS and calendar logic to shade days green or red for available or unavailable entries.

## Testing
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68a21f2f15c8832398a1cef5e05f03b4