### PR TITLE
Fix routing for rider editing

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -67,7 +67,7 @@ const PERMISSIONS_MATRIX = {
       send_notifications: true
     },
     // Pages
-    pages: ['dashboard', 'requests', 'assignments', 'riders', 'notifications', 'reports', 'admin-schedule', 'settings']
+    pages: ['dashboard', 'requests', 'assignments', 'riders', 'edit-rider', 'notifications', 'reports', 'admin-schedule', 'settings']
   },
 
   dispatcher: {
@@ -1168,7 +1168,7 @@ function checkPageAccessSafe(pageName, user, rider) {
   try {
     const rolePermissions = {
       admin: [
-        'dashboard', 'requests', 'assignments', 'riders', 'notifications', 
+        'dashboard', 'requests', 'assignments', 'riders', 'edit-rider', 'notifications',
         'reports', 'admin-schedule', 'user-management', 'auth-setup'
       ],
       dispatcher: [
@@ -1687,6 +1687,7 @@ function getPageFileNameSafe(pageName, userRole) {
       'requests': 'requests',
       'assignments': 'assignments',
       'riders': 'riders',
+      'edit-rider': 'edit-rider',
       'notifications': 'notifications',
       'reports': 'reports'
     };

--- a/Code.gs
+++ b/Code.gs
@@ -6582,6 +6582,7 @@ function getPageFileNameSafe(pageName, userRole) {
       'requests': 'requests',
       'assignments': 'assignments',
       'riders': 'riders',
+      'edit-rider': 'edit-rider',
       'notifications': 'notifications',
       'reports': 'reports',
       'rider-schedule': 'rider-schedule',
@@ -6875,6 +6876,7 @@ function getPageFileNameSafe(pageName, userRole) {
       'requests': 'requests',
       'assignments': 'assignments',
       'riders': 'riders',
+      'edit-rider': 'edit-rider',
       'notifications': 'notifications',
       'reports': 'reports'
     };
@@ -7542,6 +7544,7 @@ function checkPageAccess(pageName, user, rider) {
       'requests',
       'assignments',
       'riders',
+      'edit-rider',
       'notifications',
       'reports',
       'admin-schedule',
@@ -7599,6 +7602,7 @@ function getPageFileName(pageName, userRole) {
     'requests': 'requests',
     'assignments': 'assignments',
     'riders': 'riders',
+    'edit-rider': 'edit-rider',
     'rider-schedule': 'rider-schedule',
     'admin-schedule': 'admin-schedule',
     'notifications': 'notifications',


### PR DESCRIPTION
## Summary
- map `edit-rider` page so clicking a rider opens the edit form
- allow admins to access `edit-rider`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a245a47b308323be9384cd50121500