### PR TITLE
Remove organization field from rider edit screens

### DIFF
--- a/edit-rider.html
+++ b/edit-rider.html
@@ -76,9 +76,6 @@
     <label>Certification
       <input type="text" id="certification">
     </label>
-    <label>Organization
-      <input type="text" id="organization">
-    </label>
     <label>Total Assignments
       <input type="number" id="totalAssignments" disabled>
     </label>
@@ -122,7 +119,6 @@
       document.getElementById('platoon').value = rider.platoon || '';
       document.getElementById('partTime').value = rider.partTime || 'No';
       document.getElementById('certification').value = rider.certification || '';
-      document.getElementById('organization').value = rider.organization || '';
       document.getElementById('totalAssignments').value = rider.totalAssignments || '';
       document.getElementById('lastAssignmentDate').value = rider.lastAssignmentDate || '';
     }
@@ -136,8 +132,7 @@
         'Status': document.getElementById('status').value,
         'Platoon': document.getElementById('platoon').value,
         'Part-Time Rider': document.getElementById('partTime').value,
-        'Certification': document.getElementById('certification').value,
-        'Organization': document.getElementById('organization').value
+        'Certification': document.getElementById('certification').value
       };
       if(google && google.script && google.script.run){
         google.script.run.withSuccessHandler(res=>showMessage(res.message || 'Saved'))

--- a/riders.html
+++ b/riders.html
@@ -148,9 +148,6 @@
       <label>Certification
         <input type="text" id="editCertification">
       </label>
-      <label>Organization
-        <input type="text" id="editOrganization">
-      </label>
       <label>Total Assignments
         <input type="number" id="editTotalAssignments" disabled>
       </label>
@@ -218,7 +215,6 @@
       document.getElementById('editPlatoon').value = rider.platoon || '';
       document.getElementById('editPartTime').value = rider.partTime || 'No';
       document.getElementById('editCertification').value = rider.certification || '';
-      document.getElementById('editOrganization').value = rider.organization || '';
       document.getElementById('editTotalAssignments').value = rider.totalAssignments || '';
       document.getElementById('editLastAssignmentDate').value = rider.lastAssignmentDate || '';
       document.getElementById('message').textContent = '';
@@ -239,8 +235,7 @@
         'Status': document.getElementById('editStatus').value,
         'Platoon': document.getElementById('editPlatoon').value,
         'Part-Time Rider': document.getElementById('editPartTime').value,
-        'Certification': document.getElementById('editCertification').value,
-        'Organization': document.getElementById('editOrganization').value
+        'Certification': document.getElementById('editCertification').value
       };
 
       if (google && google.script && google.script.run) {


### PR DESCRIPTION
## Summary
- Remove Organization input from dedicated rider edit page and related scripts
- Drop Organization field from riders modal and update save logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aadd2c3c8323bab8b408bb5fddae