### PR TITLE
Return full rider objects for editing

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -86,13 +86,7 @@ function getRidersForPage() {
 
     const riders = sheetData.data
       .map(row => mapRowToRiderObject(row, sheetData.columnMap, sheetData.headers))
-      .filter(r => r && (r.jpNumber || r.name))
-      .map(r => ({
-        jpNumber: r.jpNumber || '',
-        name: r.name || '',
-        phone: r.phone || '',
-        status: r.status || ''
-      }));
+      .filter(r => r && (r.jpNumber || r.name));
 
     return { success: true, riders };
   } catch (error) {


### PR DESCRIPTION
## Summary
- Return complete rider objects from `getRidersForPage` so the edit rider screen has the data needed to populate all fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c01229dc83239d69efa91d68b567