### PR TITLE
Handle empty rider fetch results

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -174,9 +174,13 @@
     }
 
     function renderRiders(data) {
-      const riderArray = Array.isArray(data) ? data : (data && Array.isArray(data.riders) ? data.riders : null);
-      if (!riderArray) {
-        showError('No riders found');
+      const riderArray = Array.isArray(data)
+        ? data
+        : (data && Array.isArray(data.riders) ? data.riders : null);
+
+      if (!riderArray || riderArray.length === 0) {
+        const msg = data && data.message ? data.message : 'No riders found';
+        showError(msg);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Improve rider list rendering to gracefully display server error or empty state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c401574c8323bee2e3655e01369e