### PR TITLE
Fix riders page data loading

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -47,13 +47,16 @@ function getRiders() {
 }
 function getRidersForPage() {
   try {
-    // Reuse robust rider retrieval logic
-    const riders = getRiders();
+    // Delegate to the main page data loader so results stay consistent
+    const result = getPageDataForRiders();
 
-    if (!riders || riders.length === 0) {
-      return { success: false, message: 'No riders found', riders: [] };
+    if (!result || result.success === false) {
+      const message = result && (result.message || result.error) ?
+        (result.message || result.error) : 'No riders found';
+      return { success: false, message, riders: [] };
     }
 
+    const riders = Array.isArray(result.riders) ? result.riders : [];
     return { success: true, riders };
   } catch (error) {
     if (typeof logError === 'function') {

--- a/riders.html
+++ b/riders.html
@@ -167,7 +167,7 @@
         google.script.run
           .withSuccessHandler(renderRiders)
           .withFailureHandler(err => showError('Failed to load riders'))
-          .getRidersForPage();
+          .getPageDataForRiders();
       } else {
         showError('Google Apps Script runtime unavailable');
       }
@@ -176,10 +176,18 @@
     function renderRiders(data) {
       const riderArray = Array.isArray(data)
         ? data
-        : (data && Array.isArray(data.riders) ? data.riders : null);
+        : (data && Array.isArray(data.riders) ? data.riders : []);
+
+      if (!data || data.success === false) {
+        const msg = data && (data.error || data.message) ?
+          (data.error || data.message) : 'Failed to load riders';
+        showError(msg);
+        return;
+      }
 
       if (!riderArray || riderArray.length === 0) {
-        const msg = data && data.message ? data.message : 'No riders found';
+        const msg = data && (data.message || data.error) ?
+          (data.message || data.error) : 'No riders found';
         showError(msg);
         return;
       }


### PR DESCRIPTION
## Summary
- Delegate `getRidersForPage` to the main `getPageDataForRiders` API for consistent rider retrieval and error messages.
- Update riders page to call `getPageDataForRiders` and improve error handling when loading riders in the UI.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d72c9668832387b4ee42b0e26de2