### PR TITLE
Fix riders page loading to fetch riders

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -47,16 +47,13 @@ function getRiders() {
 }
 function getRidersForPage() {
   try {
-    // Delegate to the main page data loader so results stay consistent
-    const result = getPageDataForRiders();
+    // Reuse robust rider retrieval logic
+    const riders = getRiders();
 
-    if (!result || result.success === false) {
-      const message = result && (result.message || result.error) ?
-        (result.message || result.error) : 'No riders found';
-      return { success: false, message, riders: [] };
+    if (!riders || riders.length === 0) {
+      return { success: false, message: 'No riders found', riders: [] };
     }
 
-    const riders = Array.isArray(result.riders) ? result.riders : [];
     return { success: true, riders };
   } catch (error) {
     if (typeof logError === 'function') {

--- a/riders.html
+++ b/riders.html
@@ -170,7 +170,7 @@
             const msg = err && err.message ? err.message : 'Failed to load riders';
             showError(`Failed to load riders: ${msg}`);
           })
-          .getPageDataForRiders();
+          .getRidersForPage();
       } else {
         showError('Google Apps Script runtime unavailable');
       }


### PR DESCRIPTION
## Summary
- Use underlying `getRiders` logic for `getRidersForPage` to return full rider list
- Call `getRidersForPage` from `riders.html` so the page loads rider data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e457bc408323b26c1a48d0f949a5