### PR TITLE
Fix riders page loading error

### DIFF
--- a/SheetServices.gs
+++ b/SheetServices.gs
@@ -118,7 +118,8 @@ function getSheetData(sheetName, useCache = true) {
       headers: [],
       data: [],
       columnMap: {},
-      sheet: getSheet(sheetName)
+      // Do not attempt to call getSheet again here, it may throw repeatedly if the sheet is missing
+      sheet: null
     };
   }
 }


### PR DESCRIPTION
Prevent `getSheetData` from rethrowing on sheet access errors to allow graceful handling of missing sheets.

---
<a href="https://cursor.com/background-agent?bcId=bc-32a852b9-cec2-49dd-9013-0e8a50788f67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32a852b9-cec2-49dd-9013-0e8a50788f67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

