### PR TITLE
Handle empty rider IDs more robustly

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -121,7 +121,7 @@ function getRiderDetails(riderId) {
   try {
     console.log(`🔍 getRiderDetails called with: "${riderId}" (type: ${typeof riderId})`);
     
-    if (!riderId) {
+    if (riderId === undefined || riderId === null || String(riderId).trim() === '') {
       console.warn('⚠️ No rider ID provided');
       return null;
     }
@@ -513,7 +513,7 @@ function updateRider(riderData) {
     const riderIdField = CONFIG.columns.riders.jpNumber;
   const riderId = riderData[riderIdField];
 
-  if (!riderId) {
+  if (riderId === undefined || riderId === null || String(riderId).trim() === '') {
     throw new Error(`Missing Rider ID (${riderIdField}) in update data`);
   }
 


### PR DESCRIPTION
## Summary
- Avoid treating numeric rider IDs as missing in getRiderDetails
- Validate rider IDs properly in updateRider to ensure empty values are detected

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a60a9243e483239cee00afda05cf4e