### PR TITLE
Ensure rider edit links use Rider ID

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -88,7 +88,7 @@ function getRidersForPage() {
       .map(row => mapRowToRiderObject(row, sheetData.columnMap, sheetData.headers))
       .filter(r => r && (r.jpNumber || r.name))
       .map(r => ({
-        jpNumber: r.jpNumber || '',
+        riderId: r.jpNumber || '',
         name: r.name || '',
         phone: r.phone || '',
         status: r.status || ''

--- a/edit-rider.html
+++ b/edit-rider.html
@@ -127,7 +127,7 @@
     }
 
     function loadRider(){
-      const riderId = getParam('riderId') || getParam('id');
+      const riderId = getParam('riderId');
       if(!riderId){
         showMessage('No rider ID provided');
         return;
@@ -147,7 +147,7 @@
         showMessage('Rider not found');
         return;
       }
-      document.getElementById('riderId').value = rider['Rider ID'] || rider.jpNumber || '';
+      document.getElementById('riderId').value = rider['Rider ID'] || rider.riderId || rider.jpNumber || '';
       document.getElementById('fullName').value = rider['Full Name'] || rider.name || '';
       document.getElementById('phone').value = rider['Phone Number'] || rider.phone || '';
       document.getElementById('email').value = rider['Email'] || rider.email || '';

--- a/riders.html
+++ b/riders.html
@@ -81,13 +81,13 @@
       tbody.innerHTML = '';
         riders.forEach(r => {
           const tr = document.createElement('tr');
-          const identifier = r.jpNumber || r.id || '';
+          const riderId = r.riderId || r.jpNumber || '';
           const editUrl = baseUrl
-            ? `${baseUrl}?page=edit-rider&id=${encodeURIComponent(identifier)}&riderId=${encodeURIComponent(identifier)}&name=${encodeURIComponent(r.name || '')}`
-            : `edit-rider.html?id=${encodeURIComponent(identifier)}&riderId=${encodeURIComponent(identifier)}&name=${encodeURIComponent(r.name || '')}`;
+            ? `${baseUrl}?page=edit-rider&riderId=${encodeURIComponent(riderId)}`
+            : `edit-rider.html?riderId=${encodeURIComponent(riderId)}`;
           const nameCell = `<a href="${editUrl}" target="_top">${r.name || ''}</a>`;
-          const availabilityBtn = `<button onclick="openAvailability('${identifier}')">Calendar</button>`;
-          tr.innerHTML = `<td>${r.jpNumber || ''}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
+          const availabilityBtn = `<button onclick="openAvailability('${riderId}')">Calendar</button>`;
+          tr.innerHTML = `<td>${riderId}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
           tbody.appendChild(tr);
         });
 


### PR DESCRIPTION
## Summary
- Return `riderId` from `getRidersForPage`
- Build rider edit URLs using only `riderId`
- Load rider details by `riderId` parameter only

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7902564f88323a1d3b4ef46ed94e4