### PR TITLE
Fix rider ID retrieval on edit page

### DIFF
--- a/edit-rider.html
+++ b/edit-rider.html
@@ -127,18 +127,28 @@
     }
 
     function loadRider(){
-      const riderId = getParam('riderId');
-      if(!riderId){
-        showMessage('No rider ID provided');
-        return;
+      function fetchAndLoad(riderId){
+        if(!riderId){
+          showMessage('No rider ID provided');
+          return;
+        }
+        if(typeof google !== 'undefined' && google.script && google.script.run){
+          google.script.run
+            .withSuccessHandler(populateForm)
+            .withFailureHandler(function(){ showMessage('Failed to load rider'); })
+            .getRiderDetails(riderId);
+        } else {
+          showMessage('Google Apps Script runtime unavailable');
+        }
       }
-      if(typeof google !== 'undefined' && google.script && google.script.run){
-        google.script.run
-          .withSuccessHandler(populateForm)
-          .withFailureHandler(function(){ showMessage('Failed to load rider'); })
-          .getRiderDetails(riderId);
+
+      if (typeof google !== 'undefined' && google.script && google.script.url && google.script.url.getLocation){
+        google.script.url.getLocation(function(location){
+          var riderId = location && location.parameter ? location.parameter.riderId : null;
+          fetchAndLoad(riderId);
+        });
       } else {
-        showMessage('Google Apps Script runtime unavailable');
+        fetchAndLoad(getParam('riderId'));
       }
     }
 


### PR DESCRIPTION
## Summary
- Use `google.script.url.getLocation` to reliably read `riderId` on edit-rider page
- Fallback to URLSearchParams when Apps Script URL API isn't available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b3fecdb083239adebb8ac048a361