### PR TITLE
Troubleshoot rider information retrieval

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -81,13 +81,13 @@
       tbody.innerHTML = '';
         riders.forEach(r => {
           const tr = document.createElement('tr');
-          const riderId = r.riderId || r.jpNumber || '';
+          const riderIdentifier = r.riderId || r.jpNumber || r.name || '';
           const editUrl = baseUrl
-            ? `${baseUrl}?page=edit-rider&riderId=${encodeURIComponent(riderId)}`
-            : `edit-rider.html?riderId=${encodeURIComponent(riderId)}`;
+            ? `${baseUrl}?page=edit-rider&riderId=${encodeURIComponent(riderIdentifier)}`
+            : `edit-rider.html?riderId=${encodeURIComponent(riderIdentifier)}`;
           const nameCell = `<a href="${editUrl}" target="_top">${r.name || ''}</a>`;
-          const availabilityBtn = `<button onclick="openAvailability('${riderId}')">Calendar</button>`;
-          tr.innerHTML = `<td>${riderId}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
+          const availabilityBtn = `<button data-id="${encodeURIComponent(riderIdentifier)}" onclick="openAvailability(decodeURIComponent(this.dataset.id))">Calendar</button>`;
+          tr.innerHTML = `<td>${riderIdentifier}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
           tbody.appendChild(tr);
         });
 


### PR DESCRIPTION
Use rider name or JP number as a fallback identifier in `riders.html` to ensure rider details populate correctly when `riderId` is missing.

Previously, if a rider lacked a 'Rider ID' in the data sheet, the edit and calendar links would generate with an empty identifier. This prevented `getRiderDetails` from finding the rider, leading to unpopulated information. This change ensures that even without a specific 'Rider ID', the system can still identify and display rider details using available information.

---
<a href="https://cursor.com/background-agent?bcId=bc-39f85983-c76e-4480-b276-c9e9ab6b3392">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39f85983-c76e-4480-b276-c9e9ab6b3392">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

