### PR TITLE
Ensure rider lookup uses fresh data and sanitized IDs

### DIFF
--- a/RiderCRUD.gs
+++ b/RiderCRUD.gs
@@ -120,13 +120,17 @@ function getRiderDashboard(riderId) {
 function getRiderDetails(riderId) {
   try {
     console.log(`🔍 getRiderDetails called with: "${riderId}" (type: ${typeof riderId})`);
-    
+
+    // Normalize riderId early to avoid mismatches from extra spaces or number types
+    riderId = String(riderId || '').trim();
+
     if (!riderId) {
       console.warn('⚠️ No rider ID provided');
       return null;
     }
 
-    const sheetData = getSheetData(CONFIG.sheets.riders);
+    // Bypass cache so we always read the most current data from the sheet
+    const sheetData = getSheetData(CONFIG.sheets.riders, false);
     
     if (!sheetData || !sheetData.data || sheetData.data.length === 0) {
       console.log('⚠️ No rider data found in sheet');

--- a/edit-rider.html
+++ b/edit-rider.html
@@ -146,6 +146,7 @@
 
     function loadRider(){
       function fetchAndLoad(riderId){
+        riderId = (riderId || '').toString().trim();
         if(!riderId){
           showMessage('No rider ID provided');
           return;


### PR DESCRIPTION
## Summary
- Normalize and trim rider IDs in `getRiderDetails` and bypass cache to prevent stale lookups
- Sanitize rider ID parameter in the edit rider page before requesting details

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b5e73cdc83238dd8ae1d479b6f97