### PR TITLE
Ensure dashboard stats fallback when missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,6 +560,20 @@
     function updateStats(stats) {
         console.log('📊 Updating stats display:', stats);
 
+        const normalizedStats = {
+            totalRiders: 0,
+            activeRiders: 0,
+            pendingRequests: 0,
+            newRequests: 0,
+            todayAssignments: 0,
+            weekAssignments: 0,
+            ...(typeof stats === 'object' && stats !== null ? stats : {})
+        };
+
+        if (!stats || typeof stats !== 'object') {
+            console.warn('⚠️ No stats provided, using fallback values.');
+        }
+
         const safeUpdateStat = (id, value) => {
             try {
                 const element = document.getElementById(id);
@@ -575,10 +589,10 @@
             }
         };
 
-        safeUpdateStat('activeRiders', stats.activeRiders);
-        safeUpdateStat('newRequests', stats.newRequests ?? stats.pendingRequests);
-        safeUpdateStat('todayAssignments', stats.todayAssignments);
-        safeUpdateStat('weekAssignments', stats.weekAssignments);
+        safeUpdateStat('activeRiders', normalizedStats.activeRiders);
+        safeUpdateStat('newRequests', normalizedStats.newRequests ?? normalizedStats.pendingRequests);
+        safeUpdateStat('todayAssignments', normalizedStats.todayAssignments);
+        safeUpdateStat('weekAssignments', normalizedStats.weekAssignments);
     }
 
     function updateRecentRequests(requests) {


### PR DESCRIPTION
## Summary
- normalize dashboard stats payload before updating the UI
- provide fallback values when stats data is missing so the cards still render numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d28fe097808323bb48281a1a44b921