### PR TITLE
Ensure edit rider page receives rider parameters

### DIFF
--- a/AccessControl.gs
+++ b/AccessControl.gs
@@ -1424,13 +1424,15 @@ function doGet(e) {
     const navigation = getRoleBasedNavigationSafe(pageName, user, rider);
     content = content.replace('<!--NAVIGATION_MENU_PLACEHOLDER-->', navigation);
     
-    // CLEAN: Add only essential user context
-    const userScript = `<script>window.currentUser = ${JSON.stringify(user)};</script>`;
-    
+    // CLEAN: Add only essential user context and safely expose URL parameters
+    const safeUserJson = JSON.stringify(user).replace(/</g, '\\u003c');
+    const safeParamsJson = JSON.stringify(e?.parameter || {}).replace(/</g, '\\u003c');
+    const contextScript = `<script>window.currentUser = ${safeUserJson};window.pageParameters = ${safeParamsJson};</script>`;
+
     if (content.includes('</body>')) {
-      content = content.replace('</body>', userScript + '</body>');
+      content = content.replace('</body>', contextScript + '</body>');
     } else {
-      content += userScript;
+      content += contextScript;
     }
     
     return HtmlService.createHtmlOutput(content).setTitle('Motorcycle Escort Management');

--- a/edit-rider.html
+++ b/edit-rider.html
@@ -144,6 +144,15 @@
       document.getElementById('message').textContent = msg;
     }
 
+    function getFirstParamValue(params, key){
+      if(!params || !key) return null;
+      const value = params[key];
+      if(Array.isArray(value)){
+        return value.length > 0 ? value[0] : null;
+      }
+      return value !== undefined ? value : null;
+    }
+
     function loadRider(){
       function fetchAndLoad(riderId){
         riderId = (riderId || '').toString().trim();
@@ -161,11 +170,17 @@
         }
       }
 
+      const injectedParams = (typeof window !== 'undefined' && window.pageParameters) ? window.pageParameters : null;
+      const injectedRiderId = getFirstParamValue(injectedParams, 'riderId');
+
       if (typeof google !== 'undefined' && google.script && google.script.url && google.script.url.getLocation){
         google.script.url.getLocation(function(location){
-          var riderId = location && location.parameter ? location.parameter.riderId : null;
-          fetchAndLoad(riderId);
+          const locationRiderId = getFirstParamValue(location && location.parameter, 'riderId');
+          const fallbackRiderId = injectedRiderId || getParam('riderId');
+          fetchAndLoad(locationRiderId || fallbackRiderId);
         });
+      } else if (injectedRiderId) {
+        fetchAndLoad(injectedRiderId);
       } else {
         fetchAndLoad(getParam('riderId'));
       }


### PR DESCRIPTION
## Summary
- expose request parameters to rendered pages from `doGet` so client code can reliably access the rider id
- update the edit rider page to read injected parameters before falling back to Apps Script helpers, ensuring rider details load

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d454f25a3c8323b75c859d9571d989