### PR TITLE
Fix rider not found on edit click

### DIFF
--- a/riders.html
+++ b/riders.html
@@ -81,13 +81,13 @@
       tbody.innerHTML = '';
         riders.forEach(r => {
           const tr = document.createElement('tr');
-          const riderId = r.riderId || r.jpNumber || '';
+          const riderIdentifier = r.riderId || r.jpNumber || r.name || '';
           const editUrl = baseUrl
-            ? `${baseUrl}?page=edit-rider&riderId=${encodeURIComponent(riderId)}`
-            : `edit-rider.html?riderId=${encodeURIComponent(riderId)}`;
+            ? `${baseUrl}?page=edit-rider&riderId=${encodeURIComponent(riderIdentifier)}`
+            : `edit-rider.html?riderId=${encodeURIComponent(riderIdentifier)}`;
           const nameCell = `<a href="${editUrl}" target="_top">${r.name || ''}</a>`;
-          const availabilityBtn = `<button onclick="openAvailability('${riderId}')">Calendar</button>`;
-          tr.innerHTML = `<td>${riderId}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
+          const availabilityBtn = `<button onclick="openAvailability('${riderIdentifier}')">Calendar</button>`;
+          tr.innerHTML = `<td>${r.riderId || r.jpNumber || ''}</td><td>${nameCell}</td><td>${r.phone || ''}</td><td>${r.status || ''}</td><td>${availabilityBtn}</td>`;
           tbody.appendChild(tr);
         });
 


### PR DESCRIPTION
Update rider edit links to use rider name as a fallback identifier.

Previously, if a rider lacked a `riderId` or `jpNumber`, the edit link would pass an empty identifier, causing the edit page to show "Rider not found." This change ensures the edit page can always find the rider by falling back to the rider's name if an ID is missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-444b74d7-4750-4da8-8b04-8314d1f03582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-444b74d7-4750-4da8-8b04-8314d1f03582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use rider name as a fallback identifier for edit and availability links to avoid empty IDs; keep the ID column showing only riderId/jpNumber.
> 
> - **Riders page (`riders.html`)**:
>   - **Identifier logic**: Introduce `riderIdentifier = r.riderId || r.jpNumber || r.name || ''`.
>   - **Links updated**:
>     - Edit link now uses `riderIdentifier` in `riderId` query param.
>     - Availability button uses `riderIdentifier`.
>   - **Display**: ID column still shows `r.riderId || r.jpNumber || ''` (does not show name).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a83508ceebb64c9d9338875c8beca7ccc3ccd887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->